### PR TITLE
Suggested code cleanups

### DIFF
--- a/samples/SampleEphReceiver/Properties/AssemblyInfo.cs
+++ b/samples/SampleEphReceiver/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/samples/SampleSender/Properties/AssemblyInfo.cs
+++ b/samples/SampleSender/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/Microsoft.Azure.EventHubs.Processor/Checkpoint.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/Checkpoint.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.Azure.EventHubs.Processor
 {
-    using System;
-
     public class Checkpoint
     {       
         public Checkpoint(string partitionId)

--- a/src/Microsoft.Azure.EventHubs.Processor/EventProcessorHost.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/EventProcessorHost.cs
@@ -237,8 +237,10 @@ namespace Microsoft.Azure.EventHubs.Processor
                 // Override operation timeout by receive timeout?
                 if (processorOptions.ReceiveTimeout > TimeSpan.MinValue)
                 {
-                    var cbs = new EventHubsConnectionStringBuilder(this.EventHubConnectionString);
-                    cbs.OperationTimeout = processorOptions.ReceiveTimeout;
+                    var cbs = new EventHubsConnectionStringBuilder(this.EventHubConnectionString)
+                    {
+                        OperationTimeout = processorOptions.ReceiveTimeout
+                    };
                     this.EventHubConnectionString = cbs.ToString();
                 }
 

--- a/src/Microsoft.Azure.EventHubs.Processor/EventProcessorOptions.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/EventProcessorOptions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.EventHubs.Processor
             this.MaxBatchSize = 10;
             this.PrefetchCount = 300;
             this.ReceiveTimeout = TimeSpan.FromMinutes(1);
-            this.InitialOffsetProvider = (partitionId) => { return PartitionReceiver.StartOfStream; };
+            this.InitialOffsetProvider = partitionId => PartitionReceiver.StartOfStream;
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.EventHubs.Processor/ICheckpointManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/ICheckpointManager.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Azure.EventHubs.Processor
 {
-    using System;
     using System.Threading.Tasks;
 
     /// <summary>

--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionContext.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionContext.cs
@@ -4,7 +4,6 @@
 namespace Microsoft.Azure.EventHubs.Processor
 {
     using System;
-    using System.Diagnostics.Tracing;
     using System.Threading.Tasks;
 
     public class PartitionContext
@@ -94,7 +93,7 @@ namespace Microsoft.Azure.EventHubs.Processor
         internal async Task<object> GetInitialOffsetAsync() // throws InterruptedException, ExecutionException
         {
             Checkpoint startingCheckpoint = await this.host.CheckpointManager.GetCheckpointAsync(this.PartitionId);
-            Object startAt = null;
+            object startAt;
 
             if (startingCheckpoint == null)
             {

--- a/src/Microsoft.Azure.EventHubs.Processor/ProcessorEventSource.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/ProcessorEventSource.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Azure.EventHubs
 {
-    using System;
     using System.Diagnostics.Tracing;
 
     /// <summary>

--- a/src/Microsoft.Azure.EventHubs.Processor/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/Microsoft.Azure.EventHubs/Amqp/ActiveClientLinkManager.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/ActiveClientLinkManager.cs
@@ -4,7 +4,6 @@
 namespace Microsoft.Azure.EventHubs.Amqp
 {
     using System;
-    using System.Globalization;
     using System.Threading;
     using Microsoft.Azure.Amqp;
 

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
         protected override async Task OnSendAsync(IEnumerable<EventData> eventDatas, string partitionKey)
         {
-            bool shouldRetry = false;
+            bool shouldRetry;
 
             var timeoutHelper = new TimeoutHelper(this.EventHubClient.ConnectionStringBuilder.OperationTimeout, true);
 
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     link,
                     this.EventHubClient.ConnectionStringBuilder.Endpoint.AbsoluteUri, // audience
                     this.EventHubClient.ConnectionStringBuilder.Endpoint.AbsoluteUri, // endpointUri
-                    new string[] { ClaimConstants.Send },
+                    new[] { ClaimConstants.Send },
                     true,
                     expiresAt);
 

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
@@ -89,7 +89,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 // Create the link
                 var link = new RequestResponseAmqpLink(type, session, address, linkSettings.Properties);
 
-                bool isClientToken = false;
                 var authorizationValidToUtc = DateTime.MaxValue;
 
                 if (!isNamespaceScope)
@@ -106,7 +105,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     this.ConnectionStringBuilder.Endpoint.AbsoluteUri, // audience
                     this.ConnectionStringBuilder.Endpoint.AbsoluteUri, // endpointUri
                     requiredClaims,
-                    isClientToken, // ??? always false
+                    false,
                     authorizationValidToUtc);
             }
             catch (Exception)

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
@@ -106,16 +106,13 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     this.ConnectionStringBuilder.Endpoint.AbsoluteUri, // audience
                     this.ConnectionStringBuilder.Endpoint.AbsoluteUri, // endpointUri
                     requiredClaims,
-                    isClientToken,
+                    isClientToken, // ??? always false
                     authorizationValidToUtc);
             }
             catch (Exception)
             {
-                if (session != null)
-                {
-                    // Aborting the session will cleanup the link as well.
-                    session.Abort();
-                }
+                // Aborting the session will cleanup the link as well.
+                session?.Abort();
 
                 throw;
             }
@@ -176,9 +173,11 @@ namespace Microsoft.Azure.EventHubs.Amqp
             var settings = new AmqpSettings();
             if (useSslStreamSecurity && !useWebSockets && sslStreamUpgrade)
             {
-                var tlsSettings = new TlsTransportSettings();
-                tlsSettings.CertificateValidationCallback = certificateValidationCallback;
-                tlsSettings.TargetHost = sslHostName;
+                var tlsSettings = new TlsTransportSettings
+                {
+                    CertificateValidationCallback = certificateValidationCallback,
+                    TargetHost = sslHostName
+                };
 
                 var tlsProvider = new TlsTransportProvider(tlsSettings);
                 tlsProvider.Versions.Add(new AmqpVersion(amqpVersion));
@@ -197,9 +196,11 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 }
                 else if (networkCredential != null)
                 {
-                    var plainHandler = new SaslPlainHandler();
-                    plainHandler.AuthenticationIdentity = networkCredential.UserName;
-                    plainHandler.Password = networkCredential.Password;
+                    var plainHandler = new SaslPlainHandler
+                    {
+                        AuthenticationIdentity = networkCredential.UserName,
+                        Password = networkCredential.Password
+                    };
                     saslProvider.AddHandler(plainHandler);
                 }
                 else

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpMessageConverter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
         {
             AmqpMessage returnMessage = null;
             int dataCount = eventDatas.Count();
-            if (eventDatas != null && dataCount > 1)
+            if (eventDatas != null && dataCount > 1) // ??? eventData cannot be null. If it's null, line above will throw
             {
                 IList<Data> bodyList = new List<Data>();
                 EventData firstEvent = null;
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 returnMessage.MessageFormat = AmqpConstants.AmqpBatchedMessageFormat;
                 UpdateAmqpMessageHeadersAndProperties(returnMessage, null, partitionKey, firstEvent, copyUserProperties: false);
             }
-            else if (eventDatas != null && dataCount == 1)
+            else if (eventDatas != null && dataCount == 1) // ??? can't be null
             {
                 var data = eventDatas.First();
                 //this.ProcessFaultInjectionInfo(data);
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
                 foreach (var pair in eventData.Properties)
                 {
-                    object amqpObject = null;
+                    object amqpObject;
                     if (TryGetAmqpObjectFromNetObject(pair.Value, MappingType.ApplicationProperty, out amqpObject))
                     {
                         message.ApplicationProperties.Map[pair.Key] = amqpObject;
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
             }
         }
 
-        public static void UpdateEventDataHeaderAndProperties(AmqpMessage amqpMessage, EventData data)
+        private static void UpdateEventDataHeaderAndProperties(AmqpMessage amqpMessage, EventData data)
         {
             //Fx.AssertAndThrow(amqpMessage.DeliveryTag != null, "AmqpMessage should always contain delivery tag.");
             //data.DeliveryTag = amqpMessage.DeliveryTag;
@@ -192,25 +192,25 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 }
 
                 string partitionKey;
-                if (amqpMessage.MessageAnnotations.Map.TryGetValue<string>(PartitionKeyName, out partitionKey))
+                if (amqpMessage.MessageAnnotations.Map.TryGetValue(AmqpMessageConverter.PartitionKeyName, out partitionKey))
                 {
                     data.SystemProperties.PartitionKey = partitionKey;
                 }
 
                 DateTime enqueuedTimeUtc;
-                if (amqpMessage.MessageAnnotations.Map.TryGetValue<DateTime>(AmqpMessageConverter.EnqueuedTimeUtcName, out enqueuedTimeUtc))
+                if (amqpMessage.MessageAnnotations.Map.TryGetValue(AmqpMessageConverter.EnqueuedTimeUtcName, out enqueuedTimeUtc))
                 {
                     data.SystemProperties.EnqueuedTimeUtc = enqueuedTimeUtc;
                 }
 
                 long sequenceNumber;
-                if (amqpMessage.MessageAnnotations.Map.TryGetValue<long>(AmqpMessageConverter.SequenceNumberName, out sequenceNumber))
+                if (amqpMessage.MessageAnnotations.Map.TryGetValue(AmqpMessageConverter.SequenceNumberName, out sequenceNumber))
                 {
                     data.SystemProperties.SequenceNumber = sequenceNumber;
                 }
 
                 string offset;
-                if (amqpMessage.MessageAnnotations.Map.TryGetValue<string>(AmqpMessageConverter.OffsetName, out offset))
+                if (amqpMessage.MessageAnnotations.Map.TryGetValue(AmqpMessageConverter.OffsetName, out offset))
                 {
                     data.SystemProperties.Offset = offset;
                 }
@@ -330,8 +330,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
                         amqpObject = new AmqpMap((IDictionary)netObject);
                     }
                     break;
-                default:
-                    break;
             }
 
             return amqpObject != null;
@@ -423,8 +421,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     {
                         netObject = amqpObject;
                     }
-                    break;
-                default:
                     break;
             }
 

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpMessageConverter.cs
@@ -45,9 +45,12 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
         public static AmqpMessage EventDatasToAmqpMessage(IEnumerable<EventData> eventDatas, string partitionKey, bool batchable)
         {
+            if (eventDatas == null)
+                throw new ArgumentNullException(nameof(eventDatas));
+
             AmqpMessage returnMessage = null;
-            int dataCount = eventDatas.Count();
-            if (eventDatas != null && dataCount > 1) // ??? eventData cannot be null. If it's null, line above will throw
+            var dataCount = eventDatas.Count();
+            if (dataCount > 1)
             {
                 IList<Data> bodyList = new List<Data>();
                 EventData firstEvent = null;
@@ -77,7 +80,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 returnMessage.MessageFormat = AmqpConstants.AmqpBatchedMessageFormat;
                 UpdateAmqpMessageHeadersAndProperties(returnMessage, null, partitionKey, firstEvent, copyUserProperties: false);
             }
-            else if (eventDatas != null && dataCount == 1) // ??? can't be null
+            else if (dataCount == 1) // ??? can't be null
             {
                 var data = eventDatas.First();
                 //this.ProcessFaultInjectionInfo(data);

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -6,11 +6,9 @@ namespace Microsoft.Azure.EventHubs.Amqp
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Amqp;
-    using Microsoft.Azure.Amqp.Encoding;
     using Microsoft.Azure.Amqp.Framing;
 
     class AmqpPartitionReceiver : PartitionReceiver
@@ -52,7 +50,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
         protected override async Task<IList<EventData>> OnReceiveAsync(int maxMessageCount, TimeSpan waitTime)
         {
-            bool shouldRetry = false;
+            bool shouldRetry;
 
             var timeoutHelper = new TimeoutHelper(waitTime, true);
 
@@ -68,7 +66,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                         IEnumerable<AmqpMessage> amqpMessages = null;
                         bool hasMessages = await Task.Factory.FromAsync(
                             (c, s) => receiveLink.BeginReceiveMessages(maxMessageCount, timeoutHelper.RemainingTime(), c, s),
-                            (a) => receiveLink.EndReceiveMessages(a, out amqpMessages),
+                            a => receiveLink.EndReceiveMessages(a, out amqpMessages),
                             this);
 
                         if (receiveLink.TerminalException != null)
@@ -214,7 +212,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     link,
                     this.EventHubClient.ConnectionStringBuilder.Endpoint.AbsoluteUri, // audience
                     this.EventHubClient.ConnectionStringBuilder.Endpoint.AbsoluteUri, // endpointUri
-                    new string[] { ClaimConstants.Listen },
+                    new[] { ClaimConstants.Listen },
                     true,
                     expiresAt);
 
@@ -264,8 +262,8 @@ namespace Microsoft.Azure.EventHubs.Amqp
         static long TimeStampEncodingGetMilliseconds(DateTime value)
         {
             DateTime utcValue = value.ToUniversalTime();
-            double millisecs = (utcValue - AmqpConstants.StartOfEpoch).TotalMilliseconds;
-            return (long)millisecs;
+            double milliseconds = (utcValue - AmqpConstants.StartOfEpoch).TotalMilliseconds;
+            return (long)milliseconds;
         }
 
         async Task ReceivePumpAsync(CancellationToken cancellationToken)
@@ -285,10 +283,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                             // Pump has been shutdown, nothing more to do.
                             return;
                         }
-                        else
-                        {
-                            batchSize = receiveHandler.MaxBatchSize;
-                        }
+                        batchSize = receiveHandler.MaxBatchSize;
                     }
 
                     receivedEvents = await this.ReceiveAsync(batchSize);

--- a/src/Microsoft.Azure.EventHubs/Amqp/Management/RealProxy.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/Management/RealProxy.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Azure.EventHubs.Amqp.Management
                 packedArr.EndSet(this.fields[0].FieldType);
 
                 // packed[PackedArgs.DeclaringTypePosition] = typeof(iface);
-                MethodInfo Type_GetTypeFromHandle = typeof(Type).GetMethod("GetTypeFromHandle", new Type[] { typeof(RuntimeTypeHandle) });
+                MethodInfo Type_GetTypeFromHandle = typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) });
                 int methodToken;
                 Type declaringType;
                 assembly.GetTokenForMethod(mi, out declaringType, out methodToken);
@@ -451,7 +451,7 @@ namespace Microsoft.Azure.EventHubs.Amqp.Management
                     Debug.Assert(!isAddress);
                     Type argType = source.GetElementType();
                     Ldind(il, argType);
-                    Convert(il, argType, target, isAddress); //??? always false
+                    Convert(il, argType, target, false); //??? always false
                     return;
                 }
                 if (target.GetTypeInfo().IsValueType)

--- a/src/Microsoft.Azure.EventHubs/EventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/EventDataSender.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Azure.EventHubs
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -35,7 +34,8 @@ namespace Microsoft.Azure.EventHubs
             {
                 throw Fx.Exception.Argument(nameof(eventDatas), Resources.EventDataListIsNullOrEmpty);
             }
-            else if (partitionId != null && partitionKey != null)
+
+            if (partitionId != null && partitionKey != null)
             {
                 throw Fx.Exception.Argument(nameof(partitionKey), Resources.PartitionInvalidPartitionKey.FormatForUser(partitionKey, partitionId));
             }

--- a/src/Microsoft.Azure.EventHubs/EventHubsEventSource.cs
+++ b/src/Microsoft.Azure.EventHubs/EventHubsEventSource.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Azure.EventHubs
 {
-    using System;
     using System.Diagnostics.Tracing;
 
     /// <summary>

--- a/src/Microsoft.Azure.EventHubs/PartitionSender.cs
+++ b/src/Microsoft.Azure.EventHubs/PartitionSender.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.EventHubs
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
 
     /// <summary>

--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.EventHubs
 {
     using System;
     using System.Text;
-    using Microsoft.Azure.EventHubs.Amqp;
 
     /// <summary>
     /// EventHubsConnectionStringBuilder can be used to construct a connection string which can establish communication with Event Hubs entities.

--- a/src/Microsoft.Azure.EventHubs/Primitives/MessagingEntityNotFoundException.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/MessagingEntityNotFoundException.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.Azure.EventHubs
 {
-    using System;
-
     public sealed class MessagingEntityNotFoundException : EventHubsException
     {
         public MessagingEntityNotFoundException(string message)

--- a/src/Microsoft.Azure.EventHubs/Primitives/MessagingEntityType.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/MessagingEntityType.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Azure.EventHubs
         Partition = 9,
         Checkpoint = 10,
         RevokedPublisher = 11,
-        Unknown = (int)0x7FFFFFFE,
+        Unknown = 0x7FFFFFFE,
     }
 }

--- a/src/Microsoft.Azure.EventHubs/Primitives/RetryExponential.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/RetryExponential.cs
@@ -4,9 +4,6 @@
 namespace Microsoft.Azure.EventHubs
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// RetryPolicy implementation where the delay between retries will grow in a staggered exponential manner.

--- a/src/Microsoft.Azure.EventHubs/Primitives/RetryPolicy.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/RetryPolicy.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.EventHubs
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Threading;
 
     public abstract class RetryPolicy
     {

--- a/src/Microsoft.Azure.EventHubs/Primitives/SecurityToken.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/SecurityToken.cs
@@ -65,58 +65,19 @@ namespace Microsoft.Azure.EventHubs
             GetExpirationDateAndAudienceFromToken(tokenString, out this.expiresAtUtc, out this.audience);
         }
 
-        public string Audience
-        {
-            get
-            {
-                return this.audience;
-            }
-        }
+        public string Audience => this.audience;
 
-        public DateTime ExpiresAtUtc
-        {
-            get
-            {
-                return this.expiresAtUtc;
-            }
-        }
+        public DateTime ExpiresAtUtc => this.expiresAtUtc;
 
-        protected virtual string ExpiresOnFieldName
-        {
-            get
-            {
-                return InternalExpiresOnFieldName;
-            }
-        }
+        protected virtual string ExpiresOnFieldName => InternalExpiresOnFieldName;
 
-        protected virtual string AudienceFieldName
-        {
-            get
-            {
-                return InternalAudienceFieldName;
-            }
-        }
+        protected virtual string AudienceFieldName => InternalAudienceFieldName;
 
-        protected virtual string KeyValueSeparator
-        {
-            get
-            {
-                return InternalKeyValueSeparator;
-            }
-        }
+        protected virtual string KeyValueSeparator => InternalKeyValueSeparator;
 
-        protected virtual string PairSeparator
-        {
-            get
-            {
-                return InternalPairSeparator;
-            }
-        }
+        protected virtual string PairSeparator => InternalPairSeparator;
 
-        public object TokenValue
-        {
-            get { return this.token; }
-        }
+        public object TokenValue => this.token;
 
         string GetAudienceFromToken(string token)
         {
@@ -150,10 +111,10 @@ namespace Microsoft.Azure.EventHubs
         static IDictionary<string, string> Decode(string encodedString, Func<string, string> keyDecoder, Func<string, string> valueDecoder, string keyValueSeparator, string pairSeparator)
         {
             IDictionary<string, string> dictionary = new Dictionary<string, string>();
-            IEnumerable<string> valueEncodedPairs = encodedString.Split(new string[] { pairSeparator }, StringSplitOptions.None);
+            IEnumerable<string> valueEncodedPairs = encodedString.Split(new[] { pairSeparator }, StringSplitOptions.None);
             foreach (string valueEncodedPair in valueEncodedPairs)
             {
-                string[] pair = valueEncodedPair.Split(new string[] { keyValueSeparator }, StringSplitOptions.None);
+                string[] pair = valueEncodedPair.Split(new[] { keyValueSeparator }, StringSplitOptions.None);
                 if (pair.Length != 2)
                 {
                     throw new FormatException(Resources.InvalidEncoding);

--- a/src/Microsoft.Azure.EventHubs/Primitives/SharedAccessSignatureTokenProvider.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/SharedAccessSignatureTokenProvider.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.EventHubs
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
-    using System.Linq;
     using System.Net;
     using System.Security.Cryptography;
     using System.Text;
@@ -31,12 +30,7 @@ namespace Microsoft.Azure.EventHubs
             this.sharedAccessSignature = sharedAccessSignature;
         }
 
-        internal SharedAccessSignatureTokenProvider(string keyName, string sharedAccessKey, TimeSpan tokenTimeToLive)
-            : this(keyName, sharedAccessKey, tokenTimeToLive, TokenScope.Entity)
-        {
-        }
-
-        internal SharedAccessSignatureTokenProvider(string keyName, string sharedAccessKey, TimeSpan tokenTimeToLive, TokenScope tokenScope)
+        internal SharedAccessSignatureTokenProvider(string keyName, string sharedAccessKey, TimeSpan tokenTimeToLive, TokenScope tokenScope = TokenScope.Entity)
             : this(keyName, sharedAccessKey, MessagingTokenProviderKeyEncoder, tokenTimeToLive, tokenScope)
         {
         }
@@ -163,43 +157,19 @@ namespace Microsoft.Azure.EventHubs
             {
             }
 
-            protected override string AudienceFieldName
-            {
-                get
-                {
-                    return SignedResourceFullFieldName;
-                }
-            }
+            protected override string AudienceFieldName => SignedResourceFullFieldName;
 
-            protected override string ExpiresOnFieldName
-            {
-                get
-                {
-                    return SignedExpiry;
-                }
-            }
+            protected override string ExpiresOnFieldName => SignedExpiry;
 
-            protected override string KeyValueSeparator
-            {
-                get
-                {
-                    return SasKeyValueSeparator;
-                }
-            }
+            protected override string KeyValueSeparator => SasKeyValueSeparator;
 
-            protected override string PairSeparator
-            {
-                get
-                {
-                    return SasPairSeparator;
-                }
-            }
+            protected override string PairSeparator => SasPairSeparator;
 
             internal static void Validate(string sharedAccessSignature)
             {
                 if (string.IsNullOrEmpty(sharedAccessSignature))
                 {
-                    throw new ArgumentNullException("sharedAccessSignature");
+                    throw new ArgumentNullException(nameof(sharedAccessSignature));
                 }
 
                 IDictionary<string, string> parsedFields = ExtractFieldValues(sharedAccessSignature);
@@ -235,17 +205,17 @@ namespace Microsoft.Azure.EventHubs
 
                 if (!string.Equals(tokenLines[0].Trim(), SharedAccessSignature, StringComparison.OrdinalIgnoreCase) || tokenLines.Length != 2)
                 {
-                    throw new ArgumentNullException("sharedAccessSignature");
+                    throw new ArgumentNullException(nameof(sharedAccessSignature));
                 }
 
                 IDictionary<string, string> parsedFields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                string[] tokenFields = tokenLines[1].Trim().Split(new string[] { SasPairSeparator }, StringSplitOptions.None);
+                string[] tokenFields = tokenLines[1].Trim().Split(new[] { SasPairSeparator }, StringSplitOptions.None);
 
                 foreach (string tokenField in tokenFields)
                 {
                     if (tokenField != string.Empty)
                     {
-                        string[] fieldParts = tokenField.Split(new string[] { SasKeyValueSeparator }, StringSplitOptions.None);
+                        string[] fieldParts = tokenField.Split(new[] { SasKeyValueSeparator }, StringSplitOptions.None);
                         if (string.Equals(fieldParts[0], SignedResource, StringComparison.OrdinalIgnoreCase))
                         {
                             // We need to preserve the casing of the escape characters in the audience,

--- a/src/Microsoft.Azure.EventHubs/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.EventHubs/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
@@ -6,10 +6,8 @@
     using System.Diagnostics;
     using System.Linq;
     using System.Text;
-    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
-    using Xunit.Abstractions;
 
     public class EventProcessorHostTests
     {
@@ -379,7 +377,7 @@
         [Fact]
         async Task MultipleConsumerGroups()
         {
-            var consumerGroupNames = new string[] { PartitionReceiver.DefaultConsumerGroupName, "cgroup1"};
+            var consumerGroupNames = new[] { PartitionReceiver.DefaultConsumerGroupName, "cgroup1"};
             var processorOptions = new EventProcessorOptions { ReceiveTimeout = TimeSpan.FromSeconds(15) };
             var processorFactory = new TestEventProcessorFactory();
             var partitionReceiveEvents = new ConcurrentDictionary<string, AsyncAutoResetEvent>();
@@ -477,7 +475,7 @@
             var processorOptions = new EventProcessorOptions
             {
                 ReceiveTimeout = TimeSpan.FromSeconds(15),
-                InitialOffsetProvider = (partitionId) => lastEnqueueDateTime
+                InitialOffsetProvider = partitionId => lastEnqueueDateTime
             };
 
             var receivedEvents = await this.RunGenericScenario(eventProcessorHost, processorOptions);
@@ -503,7 +501,7 @@
             var processorOptions = new EventProcessorOptions
             {
                 ReceiveTimeout = TimeSpan.FromSeconds(15),
-                InitialOffsetProvider = (partitionId) => lastEvents[partitionId].SystemProperties.Offset
+                InitialOffsetProvider = partitionId => lastEvents[partitionId].SystemProperties.Offset
             };
 
             var receivedEvents = await this.RunGenericScenario(eventProcessorHost, processorOptions);
@@ -539,7 +537,7 @@
             var processorOptions = new EventProcessorOptions
             {
                 ReceiveTimeout = TimeSpan.FromSeconds(15),
-                InitialOffsetProvider = (partitionId) => PartitionReceiver.StartOfStream
+                InitialOffsetProvider = partitionId => PartitionReceiver.StartOfStream
             };
             var receivedEvents = await this.RunGenericScenario(eventProcessorHost, processorOptions);
 

--- a/test/Microsoft.Azure.EventHubs.Processor.UnitTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.Azure.EventHubs.Processor.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/test/Microsoft.Azure.EventHubs.UnitTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following


### PR DESCRIPTION
Mostly things like
- unused namespace
- exception re-throwing
- auto properties / expression based properties
- redundant else/ default case
- redundant parenthesis 
- redundant variable initialization
- unnecessary await
- constructor initialization
- //??? comments where logic is in question
- null-conditional operator
- method visibility
- nameof() instead of hardcoding argument name
- Assert.Throws instead of try/catch