### PR TITLE
Fix eph unit tests and exception contract

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpExceptionHelper.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Azure.EventHubs.Amqp
 {
     using System;
     using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Amqp.Encoding;
     using Microsoft.Azure.Amqp.Framing;
@@ -75,7 +77,8 @@ namespace Microsoft.Azure.EventHubs.Amqp
             }
             else if (string.Equals(condition, AmqpErrorCode.NotFound.Value))
             {
-                if (message.ToLower().Contains("status-code: 404"))
+                if (message.ToLower().Contains("status-code: 404") ||
+                    Regex.IsMatch(message, "The messaging entity .* could not be found"))
                 {
                     return new MessagingEntityNotFoundException(message);
                 }

--- a/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
@@ -242,7 +242,7 @@
                 }
                 await Task.WhenAll(sendTasks);
 
-                WriteLine($"Verifying an event was received by each partition");
+                WriteLine("Verifying an event was received by each partition");
                 foreach (var partitionId in PartitionIds)
                 {
                     var receivedEvent = partitionReceiveEvents[partitionId];
@@ -451,7 +451,7 @@
                     hosts.Add(eventProcessorHost);
                 }
 
-                WriteLine($"Sending an event to each partition");
+                WriteLine("Sending an event to each partition");
                 var sendTasks = new List<Task>();
                 foreach (var partitionId in PartitionIds)
                 {
@@ -460,7 +460,7 @@
 
                 await Task.WhenAll(sendTasks);
 
-                WriteLine($"Verifying an event was received by each partition for each consumer group");
+                WriteLine("Verifying an event was received by each partition for each consumer group");
                 foreach (var consumerGroupName in consumerGroupNames)
                 {
                     foreach (var partitionId in PartitionIds)
@@ -471,11 +471,11 @@
                     }
                 }
 
-                WriteLine($"Success");
+                WriteLine("Success");
             }
             finally
             {
-                WriteLine($"Calling UnregisterEventProcessorAsync on both hosts.");
+                WriteLine("Calling UnregisterEventProcessorAsync on both hosts.");
                 foreach (var eph in hosts)
                 {
                     await eph.UnregisterEventProcessorAsync();

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -623,59 +623,42 @@
         async Task SendReceiveNonexistentEntity()
         {
             // Rebuild connection string with a nonexistent entity.
-            var conSettings = new EventHubsConnectionStringBuilder(this.connectionString);
-            conSettings.EntityPath = Guid.NewGuid().ToString();
-            var ehClient = EventHubClient.CreateFromConnectionString(conSettings.ToString());
+            var csb = new EventHubsConnectionStringBuilder(this.connectionString);
+            csb.EntityPath = Guid.NewGuid().ToString();
+            var ehClient = EventHubClient.CreateFromConnectionString(csb.ToString());
 
             // Try sending.
-            try
+            PartitionSender sender = null;
+            await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
             {
                 WriteLine("Sending an event to nonexistent entity.");
-                var sender = ehClient.CreatePartitionSender("0");
+                sender = ehClient.CreatePartitionSender("0");
                 await sender.SendAsync(new EventData(Encoding.UTF8.GetBytes("this send should fail.")));
                 throw new InvalidOperationException("Send should have failed");
-            }
-            catch (MessagingEntityNotFoundException)
-            {
-                WriteLine("Caught expected MessagingEntityNotFoundException");
-            }
+            });
+            await sender.CloseAsync();
 
             // Try receiving.
             PartitionReceiver receiver = null;
-            try
+            await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
             {
                 WriteLine("Receiving from nonexistent entity.");
                 receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", PartitionReceiver.StartOfStream);
                 await receiver.ReceiveAsync(1);
                 throw new InvalidOperationException("Receive should have failed");
-            }
-            catch (MessagingEntityNotFoundException)
-            {
-                WriteLine("Caught expected MessagingEntityNotFoundException");
-            }
-            finally
-            {
-                await receiver.CloseAsync();
-            }
+            });
+            await receiver.CloseAsync();
 
             // Try receiving on an nonexistent consumer group.
             ehClient = EventHubClient.CreateFromConnectionString(this.connectionString);
-            try
+            await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
             {
                 WriteLine("Receiving from nonexistent consumer group.");
                 receiver = ehClient.CreateReceiver(Guid.NewGuid().ToString(), "0", PartitionReceiver.StartOfStream);
                 await receiver.ReceiveAsync(1);
                 throw new InvalidOperationException("Receive should have failed");
-            }
-            catch (MessagingEntityNotFoundException)
-            {
-                WriteLine("Caught expected MessagingEntityNotFoundException");
-            }
-            finally
-            {
-                await receiver.CloseAsync();
-            }
-
+            });
+            await receiver.CloseAsync();
         }
 
         [Fact]

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -113,6 +113,7 @@
                 throw new InvalidOperationException("Receive should have failed");
             });
         }
+
         [Fact]
         Task CreateClientWithoutEntityPathShouldFail()
         {
@@ -126,6 +127,7 @@
                  throw new Exception("Entity path wasn't provided in the connection string and this new call was supposed to fail");
              });
         }
+
         [Fact]
         Task EventHubClientSend()
         {


### PR DESCRIPTION
- EPH tests to unregister the active hosts at the end of the run otherwise existing hosts keep interfering with next tests. This is addressing the issue tracked by https://github.com/Azure/azure-event-hubs-dotnet/issues/21
- Improving exception contrat to handle nonexistent consumer group case.