### PR TITLE
Type cache concurrency

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/Management/AmqpServiceClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/Management/AmqpServiceClient.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.EventHubs.Amqp.Management
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
@@ -166,7 +167,7 @@ namespace Microsoft.Azure.EventHubs.Amqp.Management
         }
 
         const BindingFlags MethodFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
-        static Dictionary<Type, Dictionary<string, MethodData>> typeCache = new Dictionary<Type, Dictionary<string, MethodData>>();
+        static ConcurrentDictionary<Type, Dictionary<string, MethodData>> typeCache = new ConcurrentDictionary<Type, Dictionary<string, MethodData>>();
 
         class AmqpClientProxy : RealProxy
         {

--- a/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
@@ -45,6 +45,7 @@
             this.LeaseContainerName = this.ConnectionStringBuilder.EntityPath.ToLower();
 
             // Discover partition ids.
+            Log("Discovering partitions on eventhub");
             var ehClient = EventHubClient.CreateFromConnectionString(this.EventHubConnectionString);
             var eventHubInfo = ehClient.GetRuntimeInformationAsync().Result;
             this.PartitionIds = eventHubInfo.PartitionIds;
@@ -514,6 +515,7 @@
         {
             // Generate a new lease container name that will be used through out the test.
             string leaseContainerName = Guid.NewGuid().ToString();
+            Log($"Using lease container {leaseContainerName}");
 
             // First host will send and receive as usual.
             var eventProcessorHost = new EventProcessorHost(
@@ -538,7 +540,7 @@
                 ReceiveTimeout = TimeSpan.FromSeconds(15),
                 InitialOffsetProvider = partitionId => PartitionReceiver.StartOfStream
             };
-            var receivedEvents = await this.RunGenericScenario(eventProcessorHost, processorOptions);
+            var receivedEvents = await this.RunGenericScenario(eventProcessorHost, processorOptions, checkPointLastEvent: false);
 
             // We should have received only 1 event from each partition.
             Assert.False(receivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -577,11 +577,12 @@
                     await receiver.ReceiveAsync(1, TimeSpan.FromSeconds(receiveTimeoutInSeconds));
 
                     // Receive call should have waited more than receive timeout.
-                    Assert.True(DateTime.Now > startTime.AddSeconds(receiveTimeoutInSeconds));
+                    var diff = DateTime.Now.Subtract(startTime).TotalSeconds;
+                    Assert.True(diff >= receiveTimeoutInSeconds, $"Hit timeout {diff} seconds ionto Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
 
                     // Timeout should not be late more than 5 seconds.
                     // This is just a logical buffer for timeout behavior validation.
-                    Assert.True(DateTime.Now < startTime.AddSeconds(receiveTimeoutInSeconds + 5));
+                    Assert.True(diff < receiveTimeoutInSeconds + 5, $"Hit timeout {diff} seconds ionto Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
                 }
             }
             finally

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -578,11 +578,11 @@
 
                     // Receive call should have waited more than receive timeout.
                     var diff = DateTime.Now.Subtract(startTime).TotalSeconds;
-                    Assert.True(diff >= receiveTimeoutInSeconds, $"Hit timeout {diff} seconds ionto Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
+                    Assert.True(diff >= receiveTimeoutInSeconds, $"Hit timeout {diff} seconds into Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
 
                     // Timeout should not be late more than 5 seconds.
                     // This is just a logical buffer for timeout behavior validation.
-                    Assert.True(diff < receiveTimeoutInSeconds + 5, $"Hit timeout {diff} seconds ionto Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
+                    Assert.True(diff < receiveTimeoutInSeconds + 5, $"Hit timeout {diff} seconds into Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
                 }
             }
             finally


### PR DESCRIPTION
+ Use ConcurrentDictionary on static typeCache. AmqpClient is crashing with NullRef when multiple instances are initiated around the same time.
+ Don't checkpoint in the second host in InitialOffsetProviderOverrideBehavior unit test.
+ ReceiveTimeout test to use the same time diff during validation.