### PR TITLE
Disable publicSign

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/project.json
+++ b/src/Microsoft.Azure.EventHubs.Processor/project.json
@@ -7,6 +7,7 @@
   "buildOptions": {
     "warningsAsErrors": true,
     "delaySign": true,
+    "publicSign": false,
     "keyFile": "../../build/MSSharedLibSN1024.snk"
   },
 

--- a/src/Microsoft.Azure.EventHubs/project.json
+++ b/src/Microsoft.Azure.EventHubs/project.json
@@ -7,6 +7,7 @@
   "buildOptions": {
     "warningsAsErrors": true,
     "delaySign": true,
+    "publicSign": false,
     "keyFile": "../../build/MSSharedLibSN1024.snk"
   },
 


### PR DESCRIPTION
Disable publicSign in project.json which is causing build failures on Linux and Mac.