### PR TITLE
Removing system net security dependency.

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
@@ -6,8 +6,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
     using System;
     using System.Linq;
     using System.Net;
-    using System.Net.Security;
-    using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using Microsoft.Azure.Amqp.Sasl;
     using Microsoft.Azure.Amqp;
@@ -220,8 +218,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
             int port,
             bool useSslStreamSecurity,
             bool sslStreamUpgrade = false,
-            string sslHostName = null,
-            X509Certificate2 certificate = null)
+            string sslHostName = null)
         {
             TcpTransportSettings tcpSettings = new TcpTransportSettings
             {
@@ -237,7 +234,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 TlsTransportSettings tlsSettings = new TlsTransportSettings(tcpSettings)
                 {
                     TargetHost = sslHostName ?? hostName,
-                    Certificate = certificate,
                 };
                 tpSettings = tlsSettings;
             }

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
@@ -166,7 +166,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
             bool useWebSockets = false,
             bool sslStreamUpgrade = false,
             NetworkCredential networkCredential = null,
-            RemoteCertificateValidationCallback certificateValidationCallback = null,
             bool forceTokenProvider = true)
         {
             var settings = new AmqpSettings();
@@ -174,7 +173,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
             {
                 var tlsSettings = new TlsTransportSettings
                 {
-                    CertificateValidationCallback = certificateValidationCallback,
                     TargetHost = sslHostName
                 };
 
@@ -223,8 +221,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
             bool useSslStreamSecurity,
             bool sslStreamUpgrade = false,
             string sslHostName = null,
-            X509Certificate2 certificate = null,
-            RemoteCertificateValidationCallback certificateValidationCallback = null)
+            X509Certificate2 certificate = null)
         {
             TcpTransportSettings tcpSettings = new TcpTransportSettings
             {
@@ -241,7 +238,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 {
                     TargetHost = sslHostName ?? hostName,
                     Certificate = certificate,
-                    CertificateValidationCallback = certificateValidationCallback
                 };
                 tpSettings = tlsSettings;
             }

--- a/src/Microsoft.Azure.EventHubs/project.json
+++ b/src/Microsoft.Azure.EventHubs/project.json
@@ -31,7 +31,6 @@
       "imports": "dnxcore50",
       "dependencies": {
         "NETStandard.Library": "1.6.0",
-        "System.Net.Security": "4.0.0",
         "System.Reflection": "4.1.0",
         "System.Reflection.Emit": "4.0.1",
         "System.Reflection.TypeExtensions": "4.1.0",


### PR DESCRIPTION
System.Net.Security 4.0.0 is not UWP compliant. Removing this legacy dependency since it is not used.