### PR TITLE
Improving ConnectionStringBuilder experience by enabling custom domain name.

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -30,17 +30,18 @@ namespace Microsoft.Azure.EventHubs
     /// </example>
     public class EventHubsConnectionStringBuilder
     {
+        const char KeyValueSeparator = '=';
+        const char KeyValuePairDelimiter = ';';
+
         static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromMinutes(1);
         static readonly string EndpointScheme = "amqps";
-        static readonly string DefaultSbDomain = "servicebus.windows.net";
+        static readonly string DefaultDomain = "servicebus.windows.net";
         static readonly string EndpointFormat = EndpointScheme + "://{0}.{1}";
         static readonly string EndpointConfigName = "Endpoint";
         static readonly string SharedAccessKeyNameConfigName = "SharedAccessKeyName";
         static readonly string SharedAccessKeyConfigName = "SharedAccessKey";
         static readonly string EntityPathConfigName = "EntityPath";
         static readonly string OperationTimeoutName = "OperationTimeout";
-        const char KeyValueSeparator = '=';
-        const char KeyValuePairDelimiter = ';';
 
         /// <summary>
         /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.EventHubs
         /// <param name="sharedAccessKeyName">Shared Access Key name</param>
         /// <param name="sharedAccessKey">Shared Access Key</param>
         public EventHubsConnectionStringBuilder(string namespaceName, string entityPath, string sharedAccessKeyName, string sharedAccessKey)
-            : this(namespaceName, entityPath, sharedAccessKeyName, sharedAccessKey, DefaultSbDomain)
+            : this(namespaceName, entityPath, sharedAccessKeyName, sharedAccessKey, DefaultDomain)
         {
         }
 

--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Azure.EventHubs
     {
         static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromMinutes(1);
         static readonly string EndpointScheme = "amqps";
-        static readonly string EndpointFormat = EndpointScheme + "://{0}.servicebus.windows.net";
+        static readonly string DefaultSbDomain = "servicebus.windows.net";
+        static readonly string EndpointFormat = EndpointScheme + "://{0}.{1}";
         static readonly string EndpointConfigName = "Endpoint";
         static readonly string SharedAccessKeyNameConfigName = "SharedAccessKeyName";
         static readonly string SharedAccessKeyConfigName = "SharedAccessKey";
@@ -42,23 +43,26 @@ namespace Microsoft.Azure.EventHubs
         const char KeyValuePairDelimiter = ';';
 
         /// <summary>
-        /// Build a connection string consumable by <see cref="EventHubClient.Create(string)"/>
+        /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
         /// </summary>
         /// <param name="namespaceName">Namespace name (the dns suffix, ex: .servicebus.windows.net, is not required)</param>
         /// <param name="entityPath">Entity path. For eventHubs case specify eventHub name.</param>
         /// <param name="sharedAccessKeyName">Shared Access Key name</param>
         /// <param name="sharedAccessKey">Shared Access Key</param>
         public EventHubsConnectionStringBuilder(string namespaceName, string entityPath, string sharedAccessKeyName, string sharedAccessKey)
-            : this(namespaceName, entityPath, sharedAccessKeyName, sharedAccessKey, DefaultOperationTimeout)
+            : this(namespaceName, entityPath, sharedAccessKeyName, sharedAccessKey, DefaultSbDomain)
         {
         }
 
-        EventHubsConnectionStringBuilder(
-            string namespaceName,
-            string entityPath,
-            string sharedAccessKeyName,
-            string sharedAccessKey,
-            TimeSpan operationTimeout)
+        /// <summary>
+        /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
+        /// </summary>
+        /// <param name="namespaceName">Namespace name (the dns suffix, ex: .servicebus.windows.net, is not required)</param>
+        /// <param name="entityPath">Entity path. For eventHubs case specify eventHub name.</param>
+        /// <param name="sharedAccessKeyName">Shared Access Key name</param>
+        /// <param name="sharedAccessKey">Shared Access Key</param>
+        /// <param name="endpointDomain">Defines non-default domain name for building Event Hubs endpoint URL. Default is servicebus.windows.net</param>
+        public EventHubsConnectionStringBuilder(string namespaceName, string entityPath, string sharedAccessKeyName, string sharedAccessKey, string endpointDomain)
         {
             if (string.IsNullOrWhiteSpace(namespaceName) || string.IsNullOrWhiteSpace(entityPath))
             {
@@ -68,21 +72,12 @@ namespace Microsoft.Azure.EventHubs
             {
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(string.IsNullOrWhiteSpace(sharedAccessKeyName) ? nameof(sharedAccessKeyName) : nameof(sharedAccessKey));
             }
-            
-            if (namespaceName.Contains("."))
-            {
-                // It appears to be a fully qualified host name, use it.
-                this.Endpoint = new Uri(EndpointScheme + "://" + namespaceName);
-            }
-            else
-            {
-                this.Endpoint = new Uri(EndpointFormat.FormatInvariant(namespaceName));
-            }
 
+            this.Endpoint = new Uri(EndpointFormat.FormatInvariant(namespaceName, endpointDomain));
             this.EntityPath = entityPath;
             this.SasKey = sharedAccessKey;
             this.SasKeyName = sharedAccessKeyName;
-            this.OperationTimeout = operationTimeout;
+            this.OperationTimeout = DefaultOperationTimeout;
         }
 
         /// <summary>

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using System.Threading;
@@ -62,6 +63,79 @@
             Assert.Equal(TimeSpan.FromSeconds(100), newCsb.OperationTimeout);
             Assert.Equal("newsaskeyname", newCsb.SasKeyName);
             Assert.Equal("newsaskey", newCsb.SasKey);
+        }
+
+        [Fact]
+        void ConnectionStringBuilderTestDefaultDomain()
+        {
+            var endpointFormat = "Endpoint=amqps://{0}.servicebus.windows";
+            var myNamespace = "mynamespace";
+            var entityPath = "myentity";
+            var sharedAccessKeyName = "mySAS";
+            var sharedAccessKey = "mySASKey";
+
+            // Create connection string builder instance and then generate connection string.
+            var csb = new EventHubsConnectionStringBuilder(myNamespace, entityPath, sharedAccessKeyName, sharedAccessKey);
+            var generatedConnectionString = csb.ToString();
+
+            // Validate generated connection string.
+            // Endpoint validation.
+            var expectedLiteral = string.Format(CultureInfo.InvariantCulture, endpointFormat, myNamespace);
+            Assert.True(generatedConnectionString.Contains(expectedLiteral),
+                $"Generated connection string doesn't contain expected Endpoint. Expected: '{expectedLiteral}' in '{generatedConnectionString}'");
+
+            // SAS Name
+            expectedLiteral = $"SharedAccessKeyName={sharedAccessKeyName}";
+            Assert.True(generatedConnectionString.Contains(expectedLiteral),
+                $"Generated connection string doesn't contain expected SAS Name. Expected: '{expectedLiteral}' in '{generatedConnectionString}'");
+
+            // SAS Key
+            expectedLiteral = $"SharedAccessKey={sharedAccessKey}";
+            Assert.True(generatedConnectionString.Contains(expectedLiteral),
+                $"Generated connection string doesn't contain expected SAS Key. Expected: '{expectedLiteral}' in '{generatedConnectionString}'");
+
+            // Entity Path
+            expectedLiteral = $"EntityPath={entityPath}";
+            Assert.True(generatedConnectionString.Contains(expectedLiteral),
+                $"Generated connection string doesn't contain expected SAS Key. Expected: '{expectedLiteral}' in '{generatedConnectionString}'");
+
+            // Now try creating a new ConnectionStringBuilder from generated connection string.
+            // This should not fail.
+            var csbNew = new EventHubsConnectionStringBuilder(generatedConnectionString);
+
+            // Validate new builder.
+            Assert.True(csbNew.Endpoint == csb.Endpoint, $"Original and New CSB mismatch at Endpoint. Original: {csb.Endpoint} New: {csbNew.Endpoint}");
+            Assert.True(csbNew.SasKeyName == csb.SasKeyName, $"Original and New CSB mismatch at SasKeyName. Original: {csb.SasKeyName} New: {csbNew.SasKeyName}");
+            Assert.True(csbNew.SasKey == csb.SasKey, $"Original and New CSB mismatch at SasKey. Original: {csb.SasKey} New: {csbNew.SasKey}");
+            Assert.True(csbNew.EntityPath == csb.EntityPath, $"Original and New CSB mismatch at EntityPath. Original: {csb.EntityPath} New: {csbNew.EntityPath}");
+        }
+
+        [Fact]
+        void ConnectionStringBuilderTestCustomDomain()
+        {
+            var endpointFormat = "Endpoint=amqps://{0}.{1}";
+            var customDomain = "servicebus.someotherregion.com";
+            var myNamespace = "mynamespace";
+            var entityPath = "myentity";
+            var sharedAccessKeyName = "mySAS";
+            var sharedAccessKey = "mySASKey";
+
+            // Create connection string builder instance and then generate connection string.
+            var csb = new EventHubsConnectionStringBuilder(myNamespace, entityPath, sharedAccessKeyName, sharedAccessKey, customDomain);
+            var generatedConnectionString = csb.ToString();
+
+            // Validate generated connection string.
+            // Endpoint validation.
+            var expectedLiteral = string.Format(CultureInfo.InvariantCulture, endpointFormat, myNamespace, customDomain);
+            Assert.True(generatedConnectionString.Contains(expectedLiteral),
+                $"Generated connection string doesn't contain expected Endpoint. Expected: '{expectedLiteral}' in '{generatedConnectionString}'");
+
+            // Now try creating a new ConnectionStringBuilder from generated connection string.
+            // This should not fail.
+            var csbNew = new EventHubsConnectionStringBuilder(generatedConnectionString);
+
+            // Validate new builder.
+            Assert.True(csbNew.Endpoint == csb.Endpoint, $"Original and New CSB mismatch at Endpoint. Original: {csb.Endpoint} New: {csbNew.Endpoint}");
         }
 
         [Fact]

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -66,7 +66,7 @@
         }
 
         [Fact]
-        void ConnectionStringBuilderTestDefaultDomain()
+        void ConnectionStringBuilderWithDefaultDomain()
         {
             var endpointFormat = "Endpoint=amqps://{0}.servicebus.windows";
             var myNamespace = "mynamespace";
@@ -111,7 +111,7 @@
         }
 
         [Fact]
-        void ConnectionStringBuilderTestCustomDomain()
+        void ConnectionStringBuilderWithCustomDomain()
         {
             var endpointFormat = "Endpoint=amqps://{0}.{1}";
             var customDomain = "servicebus.someotherregion.com";


### PR DESCRIPTION
Client provides a better way of accepting custom domain name from developer. 
Adding 2 more unit tests covering connection string builder usage.