### PR TITLE
Improve connection string builder to accept endpoint domain

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.EventHubs
         /// <summary>
         /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
         /// </summary>
-        /// <param name="endpointAddress">Endpoint address pointing subject Event Hubs namespace.</param>
+        /// <param name="endpointAddress">Endpoint address unique to subject Event Hubs namespace.</param>
         /// <param name="entityPath">Entity path. For eventHubs case specify eventHub name.</param>
         /// <param name="sharedAccessKeyName">Shared Access Key name</param>
         /// <param name="sharedAccessKey">Shared Access Key</param>
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.EventHubs
         /// <summary>
         /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
         /// </summary>
-        /// <param name="endpointAddress">Endpoint address pointing subject Event Hubs namespace.</param>
+        /// <param name="endpointAddress">Endpoint address unique to subject Event Hubs namespace.</param>
         /// <param name="entityPath">Entity path. For eventHubs case specify eventHub name.</param>
         /// <param name="sharedAccessKeyName">Shared Access Key name</param>
         /// <param name="sharedAccessKey">Shared Access Key</param>

--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.EventHubs
     /// Sample code:
     /// <code>
     /// var connectionStringBuiler = new EventHubsConnectionStringBuilder(
-    ///     "EventHubsNamespaceName", 
+    ///     "amqps://EventHubsNamespaceName.servicebus.windows.net", 
     ///     "EventHubsEntityName", // Event Hub Name 
     ///     "SharedAccessSignatureKeyName", 
     ///     "SharedAccessSignatureKey");
@@ -35,8 +35,6 @@ namespace Microsoft.Azure.EventHubs
 
         static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromMinutes(1);
         static readonly string EndpointScheme = "amqps";
-        static readonly string DefaultDomain = "servicebus.windows.net";
-        static readonly string EndpointFormat = EndpointScheme + "://{0}.{1}";
         static readonly string EndpointConfigName = "Endpoint";
         static readonly string SharedAccessKeyNameConfigName = "SharedAccessKeyName";
         static readonly string SharedAccessKeyConfigName = "SharedAccessKey";
@@ -46,39 +44,58 @@ namespace Microsoft.Azure.EventHubs
         /// <summary>
         /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
         /// </summary>
-        /// <param name="namespaceName">Namespace name (the dns suffix, ex: .servicebus.windows.net, is not required)</param>
+        /// <param name="endpointAddress">Endpoint address pointing subject Event Hubs namespace.</param>
         /// <param name="entityPath">Entity path. For eventHubs case specify eventHub name.</param>
         /// <param name="sharedAccessKeyName">Shared Access Key name</param>
         /// <param name="sharedAccessKey">Shared Access Key</param>
-        public EventHubsConnectionStringBuilder(string namespaceName, string entityPath, string sharedAccessKeyName, string sharedAccessKey)
-            : this(namespaceName, entityPath, sharedAccessKeyName, sharedAccessKey, DefaultDomain)
+        public EventHubsConnectionStringBuilder(
+            Uri endpointAddress,
+            string entityPath,
+            string sharedAccessKeyName,
+            string sharedAccessKey)
+            : this (endpointAddress, entityPath, sharedAccessKeyName, sharedAccessKey, DefaultOperationTimeout)
         {
         }
 
         /// <summary>
         /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
         /// </summary>
-        /// <param name="namespaceName">Namespace name (the dns suffix, ex: .servicebus.windows.net, is not required)</param>
+        /// <param name="endpointAddress">Endpoint address pointing subject Event Hubs namespace.</param>
         /// <param name="entityPath">Entity path. For eventHubs case specify eventHub name.</param>
         /// <param name="sharedAccessKeyName">Shared Access Key name</param>
         /// <param name="sharedAccessKey">Shared Access Key</param>
-        /// <param name="endpointDomain">Defines non-default domain name for building Event Hubs endpoint URL. Default is servicebus.windows.net</param>
-        public EventHubsConnectionStringBuilder(string namespaceName, string entityPath, string sharedAccessKeyName, string sharedAccessKey, string endpointDomain)
+        /// <param name="operationTimeout">Operation timeout for Event Hubs operations</param>
+        public EventHubsConnectionStringBuilder(
+            Uri endpointAddress,
+            string entityPath,
+            string sharedAccessKeyName,
+            string sharedAccessKey,
+            TimeSpan operationTimeout)
         {
-            if (string.IsNullOrWhiteSpace(namespaceName) || string.IsNullOrWhiteSpace(entityPath))
+            if (endpointAddress == null)
             {
-                throw Fx.Exception.ArgumentNullOrWhiteSpace(string.IsNullOrWhiteSpace(namespaceName) ? nameof(namespaceName) : nameof(entityPath));
+                throw Fx.Exception.ArgumentNull(nameof(endpointAddress));
+            }
+            else if (string.IsNullOrWhiteSpace(entityPath))
+            {
+                throw Fx.Exception.ArgumentNullOrWhiteSpace(nameof(entityPath));
             }
             else if (string.IsNullOrWhiteSpace(sharedAccessKeyName) || string.IsNullOrWhiteSpace(sharedAccessKey))
             {
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(string.IsNullOrWhiteSpace(sharedAccessKeyName) ? nameof(sharedAccessKeyName) : nameof(sharedAccessKey));
             }
 
-            this.Endpoint = new Uri(EndpointFormat.FormatInvariant(namespaceName, endpointDomain));
+            // Replace the scheme. We cannot really make sure that user passed an amps:// scheme to us.
+            var uriBuilder = new UriBuilder(endpointAddress.AbsoluteUri)
+            {
+                Scheme = EndpointScheme
+            };
+            this.Endpoint = uriBuilder.Uri;
+
             this.EntityPath = entityPath;
             this.SasKey = sharedAccessKey;
             this.SasKeyName = sharedAccessKeyName;
-            this.OperationTimeout = DefaultOperationTimeout;
+            this.OperationTimeout = operationTimeout;
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Azure.EventHubs
         /// <summary>
         /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
         /// </summary>
-        /// <param name="endpointAddress">Endpoint address unique to subject Event Hubs namespace.</param>
-        /// <param name="entityPath">Entity path. For eventHubs case specify eventHub name.</param>
+        /// <param name="endpointAddress">Fully qualified domain name for Event Hubs. Most likely, {yournamespace}.servicebus.windows.net</param>
+        /// <param name="entityPath">Entity path or Event Hub name.</param>
         /// <param name="sharedAccessKeyName">Shared Access Key name</param>
         /// <param name="sharedAccessKey">Shared Access Key</param>
         public EventHubsConnectionStringBuilder(
@@ -60,8 +60,8 @@ namespace Microsoft.Azure.EventHubs
         /// <summary>
         /// Build a connection string consumable by <see cref="EventHubClient.CreateFromConnectionString(string)"/>
         /// </summary>
-        /// <param name="endpointAddress">Endpoint address unique to subject Event Hubs namespace.</param>
-        /// <param name="entityPath">Entity path. For eventHubs case specify eventHub name.</param>
+        /// <param name="endpointAddress">Fully qualified domain name for Event Hubs. Most likely, {yournamespace}.servicebus.windows.net</param>
+        /// <param name="entityPath">Entity path or Event Hub name.</param>
         /// <param name="sharedAccessKeyName">Shared Access Key name</param>
         /// <param name="sharedAccessKey">Shared Access Key</param>
         /// <param name="operationTimeout">Operation timeout for Event Hubs operations</param>

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -66,21 +66,21 @@
         }
 
         [Fact]
-        void ConnectionStringBuilderWithDefaultDomain()
+        void ConnectionStringBuilderWithCustomEndpoint()
         {
-            var endpointFormat = "Endpoint=amqps://{0}.servicebus.windows";
-            var myNamespace = "mynamespace";
+            // Use 'sb' scheme intentionally. Connection string builder will replace it with 'amqps'.
+            var endpoint = new Uri("sb://mynamespace.someotherregion.windows");
             var entityPath = "myentity";
             var sharedAccessKeyName = "mySAS";
             var sharedAccessKey = "mySASKey";
 
             // Create connection string builder instance and then generate connection string.
-            var csb = new EventHubsConnectionStringBuilder(myNamespace, entityPath, sharedAccessKeyName, sharedAccessKey);
+            var csb = new EventHubsConnectionStringBuilder(endpoint, entityPath, sharedAccessKeyName, sharedAccessKey);
             var generatedConnectionString = csb.ToString();
 
             // Validate generated connection string.
             // Endpoint validation.
-            var expectedLiteral = string.Format(CultureInfo.InvariantCulture, endpointFormat, myNamespace);
+            var expectedLiteral = $"Endpoint={endpoint.ToString().Replace("sb://", "amqps://")}";
             Assert.True(generatedConnectionString.Contains(expectedLiteral),
                 $"Generated connection string doesn't contain expected Endpoint. Expected: '{expectedLiteral}' in '{generatedConnectionString}'");
 
@@ -108,34 +108,6 @@
             Assert.True(csbNew.SasKeyName == csb.SasKeyName, $"Original and New CSB mismatch at SasKeyName. Original: {csb.SasKeyName} New: {csbNew.SasKeyName}");
             Assert.True(csbNew.SasKey == csb.SasKey, $"Original and New CSB mismatch at SasKey. Original: {csb.SasKey} New: {csbNew.SasKey}");
             Assert.True(csbNew.EntityPath == csb.EntityPath, $"Original and New CSB mismatch at EntityPath. Original: {csb.EntityPath} New: {csbNew.EntityPath}");
-        }
-
-        [Fact]
-        void ConnectionStringBuilderWithCustomDomain()
-        {
-            var endpointFormat = "Endpoint=amqps://{0}.{1}";
-            var customDomain = "servicebus.someotherregion.com";
-            var myNamespace = "mynamespace";
-            var entityPath = "myentity";
-            var sharedAccessKeyName = "mySAS";
-            var sharedAccessKey = "mySASKey";
-
-            // Create connection string builder instance and then generate connection string.
-            var csb = new EventHubsConnectionStringBuilder(myNamespace, entityPath, sharedAccessKeyName, sharedAccessKey, customDomain);
-            var generatedConnectionString = csb.ToString();
-
-            // Validate generated connection string.
-            // Endpoint validation.
-            var expectedLiteral = string.Format(CultureInfo.InvariantCulture, endpointFormat, myNamespace, customDomain);
-            Assert.True(generatedConnectionString.Contains(expectedLiteral),
-                $"Generated connection string doesn't contain expected Endpoint. Expected: '{expectedLiteral}' in '{generatedConnectionString}'");
-
-            // Now try creating a new ConnectionStringBuilder from generated connection string.
-            // This should not fail.
-            var csbNew = new EventHubsConnectionStringBuilder(generatedConnectionString);
-
-            // Validate new builder.
-            Assert.True(csbNew.Endpoint == csb.Endpoint, $"Original and New CSB mismatch at Endpoint. Original: {csb.Endpoint} New: {csbNew.Endpoint}");
         }
 
         [Fact]


### PR DESCRIPTION
Replacing 'namespace' parameter with endpointAddress in the constructor. This way we don't have to hardcode 'servicebus.windows.net' default domain.