### PR TITLE
Employ get partition runtime info for discovering end of stream.

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -315,8 +315,9 @@ namespace Microsoft.Azure.EventHubs.Processor
                 // There already is a pump. Make sure the pump is working and replace the lease.
                 if (capturedPump.PumpStatus == PartitionPumpStatus.Errored || capturedPump.IsClosing)
                 {
-                    // The existing pump is bad. Remove it.
+                    // The existing pump is bad. Remove it and create a new one.
                     await RemovePumpAsync(partitionId, CloseReason.Shutdown).ConfigureAwait(false);
+                    await CreateNewPumpAsync(partitionId, lease).ConfigureAwait(false);
                 }
                 else
                 {


### PR DESCRIPTION
Small change for unit tests to save couple minutes while discovering end of stream information on the partitions. Since we now have GetPartitionRuntimeInformation API on the client, we start leveraging this instead of  walking through entire stream to reach the end.