### PR TITLE
Increasing timer tolerance buffer in RetryPolicy

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Primitives/ClientConstants.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/ClientConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.EventHubs
 {
     static class ClientConstants
     {
-        public const int TimerToleranceInSeconds = 1;
+        public const int TimerToleranceInSeconds = 5;
         public const int ServerBusyBaseSleepTimeInSecs = 4;
     }
 }


### PR DESCRIPTION
1 second is falling short for the last retry while working with large messages. .NET client is also using 5 seconds as this buffer. Short tolerance buffer is causing AMQP layers to be called with sub second values.