### PR TITLE
Adding EndOfStream receiver support

### DIFF
--- a/src/Microsoft.Azure.EventHubs/PartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/PartitionReceiver.cs
@@ -28,6 +28,12 @@ namespace Microsoft.Azure.EventHubs
         public static readonly string StartOfStream = "-1";
 
         /// <summary>
+        /// The constant that denotes the end of a stream. This can be used as an offset argument in receiver creation to 
+        /// start receiving from the latest event, instead of a specific point in time/offset value.
+        /// </summary>
+        public static readonly string EndOfStream = "@latest";
+
+        /// <summary>
         /// The default consumer group name: $Default.
         /// </summary>
         public static readonly string DefaultConsumerGroupName = "$Default";

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -268,6 +268,59 @@ namespace Microsoft.Azure.EventHubs.UnitTests
         }
 
         [Fact]
+        async Task CreateReceiverWithEndOfStream()
+        {
+            // Randomly pick one of the available partitons.
+            var partitionId = this.PartitionIds[new Random().Next(this.PartitionIds.Count())];
+            Log($"Randomly picked partition {partitionId}");
+
+            var partitionSender = this.EventHubClient.CreatePartitionSender(partitionId);
+
+            // Send couple of messages before creating an EndOfStream receiver.
+            // We are not expecting to receive these messages would be sent before receiver creation.
+            for (int i = 0; i < 10; i++)
+            {
+                var ed = new EventData(new byte[1]);
+                await partitionSender.SendAsync(ed);
+            }
+
+            // Create a new receiver which will start reading from the end of the stream.
+            Log($"Creating a new receiver with offset EndOFStream");
+            var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, PartitionReceiver.EndOfStream);
+
+            // Attemp to receive the message. This should receive only 1 message.
+            var receiveTask = receiver.ReceiveAsync(100);
+
+            // Send a new message which is expected to go to the end of stream.
+            // We are expecting to receive only this message.
+            // Wait 3 seconds before sending to avoid race.
+            await Task.Delay(3000);
+            var eventToReceive = new EventData(new byte[1]);
+            eventToReceive.Properties = new Dictionary<string, object>();
+            eventToReceive.Properties.Add("stamp", Guid.NewGuid().ToString());
+            await partitionSender.SendAsync(eventToReceive);
+
+            // Complete asyncy receive task.
+            var receivedMessages = await receiveTask;
+
+            // We should have received only 1 message from this call.
+            Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
+
+            // Check stamp.
+            Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventToReceive.Properties["stamp"].ToString()
+                , "Stamps didn't match on the message sent and received!");
+
+            Log("Received correct message as expected.");
+
+            // Next receive on this partition shouldn't return any more messages.
+            receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
+            Assert.True(receivedMessages == null, $"Received messages at the end.");
+
+            await partitionSender.CloseAsync();
+            await receiver.CloseAsync();
+        }
+
+        [Fact]
         async Task CreateReceiverWithOffset()
         {
             // Randomly pick one of the available partitons.

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -288,13 +288,13 @@ namespace Microsoft.Azure.EventHubs.UnitTests
             Log($"Creating a new receiver with offset EndOFStream");
             var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, PartitionReceiver.EndOfStream);
 
-            // Attemp to receive the message. This should receive only 1 message.
+            // Attemp to receive the message. This should return only 1 message.
             var receiveTask = receiver.ReceiveAsync(100);
 
             // Send a new message which is expected to go to the end of stream.
             // We are expecting to receive only this message.
-            // Wait 3 seconds before sending to avoid race.
-            await Task.Delay(3000);
+            // Wait 5 seconds before sending to avoid race.
+            await Task.Delay(5000);
             var eventToReceive = new EventData(new byte[1]);
             eventToReceive.Properties = new Dictionary<string, object>();
             eventToReceive.Properties.Add("stamp", Guid.NewGuid().ToString());


### PR DESCRIPTION
## Description
Adding EndOfStream receiver support and related unit tests.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [X] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
- [X] The code builds without any errors.