### PR TITLE
Fixing EPH tracing issue at PartitionPumpCreateClientsStart trace

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/EventHubPartitionPump.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/EventHubPartitionPump.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.EventHubs.Processor
             // Create new clients
             object startAt = await this.PartitionContext.GetInitialOffsetAsync().ConfigureAwait(false);
             long epoch = this.Lease.Epoch;
-            ProcessorEventSource.Log.PartitionPumpCreateClientsStart(this.Host.Id, this.PartitionContext.PartitionId, epoch, startAt);
+            ProcessorEventSource.Log.PartitionPumpCreateClientsStart(this.Host.Id, this.PartitionContext.PartitionId, epoch, startAt?.ToString());
 		    this.eventHubClient = EventHubClient.CreateFromConnectionString(this.Host.EventHubConnectionString);
 
             // Create new receiver and set options

--- a/src/Microsoft.Azure.EventHubs.Processor/ProcessorEventSource.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/ProcessorEventSource.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.EventHubs
     using System.Diagnostics.Tracing;
 
     /// <summary>
-    /// EventSource for Microsoft-Azure-EventHubs traces.
+    /// EventSource for Microsoft-Azure-EventHubs-Processor traces.
     /// 
     /// When defining Start/Stop tasks, the StopEvent.Id must be exactly StartEvent.Id + 1.
     /// 
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.EventHubs
         }
 
         [Event(57, Level = EventLevel.Informational, Message = "{0}: Partition {1}: Creating EventHubClient and PartitionReceiver with Epoch:{2} StartAt:{3}.")]
-        public void PartitionPumpCreateClientsStart(string hostId, string partitionId, long epoch, object startAt)
+        public void PartitionPumpCreateClientsStart(string hostId, string partitionId, long epoch, string startAt)
         {
             if (IsEnabled())
             {


### PR DESCRIPTION
## Description
NetCore Diagnostics.Tracing doesn't allow object type arguments. Converting @startAt argument to string type.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [X] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
- [X] The code builds without any errors.