### PR TITLE
Moving net framework to 452

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/project.json
+++ b/src/Microsoft.Azure.EventHubs.Processor/project.json
@@ -32,7 +32,7 @@
         "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
       }
     },
-    "net451": {
+    "net452": {
     },
     "netstandard1.3": {
       "imports": [

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
             do
             {
-                using (AmqpMessage amqpMessage = AmqpMessageConverter.EventDatasToAmqpMessage(eventDatas, partitionKey, true))
+                using (AmqpMessage amqpMessage = AmqpMessageConverter.EventDatasToAmqpMessage(eventDatas, partitionKey))
                 {
                     shouldRetry = false;
 

--- a/src/Microsoft.Azure.EventHubs/project.json
+++ b/src/Microsoft.Azure.EventHubs/project.json
@@ -28,7 +28,7 @@
         "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
       }
     },
-    "net451": {
+    "net452": {
     },
     "netstandard1.3": {
       "imports": "dnxcore50",


### PR DESCRIPTION
Support for .NET Framework 4, 4.5, and 4.5.1 ended on January 12, 2016. Moving framework dependency to 4.5.2

