### PR TITLE
Introduced factory method in EventData class

### DIFF
--- a/src/Microsoft.Azure.EventHubs/EventData.cs
+++ b/src/Microsoft.Azure.EventHubs/EventData.cs
@@ -77,10 +77,45 @@ namespace Microsoft.Azure.EventHubs
             get; internal set;
         }
 
+        /// <summary>
+        /// Creates EventData object with SystemProperties property populated.
+        /// Use it for test purposes only.
+        /// </summary>
+        public static EventData CreateWithSystemProperties(byte[] array, long sequenceNumber, DateTime enqueuedTimeUtc, string offset,
+            string partitionKey)
+        {
+            return new EventData(array)
+            {
+                SystemProperties = new SystemPropertiesCollection(sequenceNumber, enqueuedTimeUtc, offset, partitionKey)
+            };
+        }
+
+        /// <summary>
+        /// Creates EventData object with SystemProperties property populated.
+        /// Use it for test purposes only.
+        /// </summary>
+        public static EventData CreateWithSystemProperties(ArraySegment<byte> arraySegment, long sequenceNumber, DateTime enqueuedTimeUtc, string offset,
+            string partitionKey)
+        {
+            return new EventData(arraySegment)
+            {
+                SystemProperties = new SystemPropertiesCollection(sequenceNumber, enqueuedTimeUtc, offset, partitionKey)
+            };
+        }
+
         public sealed class SystemPropertiesCollection
         {
             internal SystemPropertiesCollection()
             {
+            }
+
+            internal SystemPropertiesCollection(long sequenceNumber, DateTime enqueuedTimeUtc, string offset,
+                string partitionKey)
+            {
+                SequenceNumber = sequenceNumber;
+                EnqueuedTimeUtc = enqueuedTimeUtc;
+                Offset = offset;
+                PartitionKey = partitionKey;
             }
 
             public long SequenceNumber

--- a/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
+++ b/test/Microsoft.Azure.EventHubs.UnitTests/EventHubClientTests.cs
@@ -894,6 +894,19 @@ namespace Microsoft.Azure.EventHubs.UnitTests
             Assert.True(edReceived.Body.Count == byteArr.Count(), $"Sent {byteArr.Count()} bytes and received {edReceived.Body.Count}");
         }
 
+        [Fact]
+        void EventDataObjectCanHaveSystemPropertiesPopulatedCorrectly()
+        {
+            byte[] byteArr = {0};
+            var eventData = EventData.CreateWithSystemProperties(new ArraySegment<byte>(byteArr), long.MinValue,
+                DateTime.MinValue, string.Empty, "foo");
+
+            Assert.True(eventData.SystemProperties.EnqueuedTimeUtc == DateTime.MinValue);
+            Assert.True(eventData.SystemProperties.Offset == string.Empty);
+            Assert.True(eventData.SystemProperties.PartitionKey == "foo");
+            Assert.True(eventData.SystemProperties.SequenceNumber == long.MinValue);
+        }
+
         // Send and receive given event on given partition.
         async Task<EventData> SendAndReceiveEvent(string partitionId, EventData sendEvent)
         {


### PR DESCRIPTION

## Description
It references issue #24 in which there's a need to ease creation of `EventData` object with SystemProperties populated for testing purpose.

Note that there's a possibility to introduce a `protected static` method, which could be used only from within derived class - what could hide it by default - but I decided, that this complicates such a simple tasks and creates too much overhead. I'm eager to discuss alternatives however.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ X] Title of the pull request is clear and informative.
- [ X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ X] If applicable, the public code is properly documented.
- [ X] Pull request includes test coverage for the included changes.
- [ ]X The code builds without any errors.