### PR TITLE
Allow at least 60 seconds for AMQP session create.

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpClientConstants.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpClientConstants.cs
@@ -69,6 +69,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
         public const string ResponseErrorCondition = "error-condition";
         public const string ResponseStatusDescription = "status-description";
 
-
+        public const int AmqpMinimumOpenSessionTimeoutInSeconds = 60;
     }
 }

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
@@ -109,7 +109,11 @@ namespace Microsoft.Azure.EventHubs.Amqp
         async Task<SendingAmqpLink> CreateLinkAsync(TimeSpan timeout)
         {
             var amqpEventHubClient = ((AmqpEventHubClient)this.EventHubClient);
-            var timeoutHelper = new TimeoutHelper(timeout);
+
+            // Allow at least AmqpMinimumOpenSessionTimeoutInSeconds seconds to open the session.
+            var openSessionTimeout = TimeSpan.FromSeconds(Math.Max(timeout.TotalSeconds, AmqpClientConstants.AmqpMinimumOpenSessionTimeoutInSeconds));
+            var timeoutHelper = new TimeoutHelper(openSessionTimeout);
+
             AmqpConnection connection = await amqpEventHubClient.ConnectionManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             // Authenticate over CBS

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
@@ -111,7 +111,8 @@ namespace Microsoft.Azure.EventHubs.Amqp
             var amqpEventHubClient = ((AmqpEventHubClient)this.EventHubClient);
 
             // Allow at least AmqpMinimumOpenSessionTimeoutInSeconds seconds to open the session.
-            var openSessionTimeout = TimeSpan.FromSeconds(Math.Max(timeout.TotalSeconds, AmqpClientConstants.AmqpMinimumOpenSessionTimeoutInSeconds));
+            var openSessionTimeout = AmqpClientConstants.AmqpMinimumOpenSessionTimeoutInSeconds > timeout.TotalSeconds ?
+                TimeSpan.FromSeconds(AmqpClientConstants.AmqpMinimumOpenSessionTimeoutInSeconds) : timeout;
             var timeoutHelper = new TimeoutHelper(openSessionTimeout);
 
             AmqpConnection connection = await amqpEventHubClient.ConnectionManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -163,7 +163,11 @@ namespace Microsoft.Azure.EventHubs.Amqp
         async Task<ReceivingAmqpLink> CreateLinkAsync(TimeSpan timeout)
         {
             var amqpEventHubClient = ((AmqpEventHubClient)this.EventHubClient);
-            var timeoutHelper = new TimeoutHelper(timeout);
+
+            // Allow at least AmqpMinimumOpenSessionTimeoutInSeconds seconds to open the session.
+            var openSessionTimeout = TimeSpan.FromSeconds(Math.Max(timeout.TotalSeconds, AmqpClientConstants.AmqpMinimumOpenSessionTimeoutInSeconds));
+            var timeoutHelper = new TimeoutHelper(openSessionTimeout);
+
             AmqpConnection connection = await amqpEventHubClient.ConnectionManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             // Authenticate over CBS

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -165,7 +165,8 @@ namespace Microsoft.Azure.EventHubs.Amqp
             var amqpEventHubClient = ((AmqpEventHubClient)this.EventHubClient);
 
             // Allow at least AmqpMinimumOpenSessionTimeoutInSeconds seconds to open the session.
-            var openSessionTimeout = TimeSpan.FromSeconds(Math.Max(timeout.TotalSeconds, AmqpClientConstants.AmqpMinimumOpenSessionTimeoutInSeconds));
+            var openSessionTimeout = AmqpClientConstants.AmqpMinimumOpenSessionTimeoutInSeconds > timeout.TotalSeconds ?
+                TimeSpan.FromSeconds(AmqpClientConstants.AmqpMinimumOpenSessionTimeoutInSeconds) : timeout;
             var timeoutHelper = new TimeoutHelper(openSessionTimeout);
 
             AmqpConnection connection = await amqpEventHubClient.ConnectionManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);

--- a/src/Microsoft.Azure.EventHubs/Primitives/AsyncLock.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/AsyncLock.cs
@@ -64,30 +64,15 @@ namespace Microsoft.Azure.EventHubs
         public struct LockRelease : IDisposable
         {
             readonly AsyncLock asyncLockRelease;
-            bool disposed;
 
             internal LockRelease(AsyncLock release)
             {
                 this.asyncLockRelease = release;
-                this.disposed = false;
             }
 
             public void Dispose()
             {
-                Dispose(true);
-            }
-
-            void Dispose(bool disposing)
-            {
-                if (!disposed)
-                {
-                    if (disposing)
-                    {
-                        asyncLockRelease?.asyncSemaphore.Release();
-                    }
-
-                    this.disposed = true;
-                }
+                asyncLockRelease?.asyncSemaphore.Release();
             }
         }
     }


### PR DESCRIPTION
AMQP session create can take a little longer than typical Send or Receive call since it might involve first time TCP connection creation. Because of this allowing a minimum duration for session creation makes sense.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.