### PR TITLE
Fix audience on the ActiveClientLink

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
                 var activeClientLink = new ActiveClientLink(
                     link,
-                    this.EventHubClient.ConnectionStringBuilder.Endpoint.AbsoluteUri, // audience
+                    audience, // audience
                     this.EventHubClient.ConnectionStringBuilder.Endpoint.AbsoluteUri, // endpointUri
                     new[] { ClaimConstants.Send },
                     true,

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 await link.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 var activeClientLink = new ActiveClientLink(
                     link,
-                    this.EventHubClient.ConnectionStringBuilder.Endpoint.AbsoluteUri, // audience
+                    audience, // audience
                     this.EventHubClient.ConnectionStringBuilder.Endpoint.AbsoluteUri, // endpointUri
                     new[] { ClaimConstants.Listen },
                     true,


### PR DESCRIPTION
Active client link's audience was set from the absolute URI of the endpoint. For entity level SAS this was causing wrong audience and token renewal to fail eventually. This change is fixing the issue by setting the correct audience required for entity level SAS.

Addressing the issue reported at https://github.com/Azure/azure-event-hubs-dotnet/issues/134

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.