### PR TITLE
Fixing receiver pump open/close race issue

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -135,7 +135,14 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     if (this.receiveHandler != null)
                     {
                         // Notify existing handler first (but don't wait).
-                        this.receiveHandler.ProcessErrorAsync(new OperationCanceledException("New handler has registered for this receiver."));
+                        Task.Run(() =>
+                            this.receiveHandler.ProcessErrorAsync(new OperationCanceledException("New handler has registered for this receiver.")))
+                            .ContinueWith(t =>
+                                t.Exception.Handle(ex =>
+                                {
+                                    // We omit any failures from ProcessErrorAsync
+                                    return true;
+                                }));
                     }
 
                     this.receiveHandler = newReceiveHandler;

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                                 {
                                     // We omit any failures from ProcessErrorAsync
                                     return true;
-                                }));
+                                }), TaskContinuationOptions.OnlyOnFaulted);
                     }
 
                     this.receiveHandler = newReceiveHandler;

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/ClientTestBase.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/ClientTestBase.cs
@@ -80,12 +80,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             return receivedEvent;
         }
 
-        protected async Task<Tuple<string, DateTime, string>> DiscoverEndOfStreamForPartition(string pid)
-        {
-            var pInfo = await this.EventHubClient.GetPartitionRuntimeInformationAsync(pid);
-            return Tuple.Create(pInfo.LastEnqueuedOffset, pInfo.LastEnqueuedTimeUtc, pInfo.LastEnqueuedOffset);
-        }
-
         // Receives all messages on the given receiver.
         protected async Task<List<EventData>> ReceiveAllMessages(PartitionReceiver receiver)
         {
@@ -116,8 +110,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             TestUtility.Log("Discovering end of stream on each partition.");
             foreach (var partitionId in this.PartitionIds)
             {
-                var lastEvent = await DiscoverEndOfStreamForPartition(partitionId);
-                receivers.Add(this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, lastEvent.Item3));
+                var lastEvent = await this.EventHubClient.GetPartitionRuntimeInformationAsync(partitionId);
+                receivers.Add(this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, lastEvent.LastEnqueuedOffset));
             }
 
             try

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/MiscTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/MiscTests.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             TestUtility.Log("Discovering end of stream on each partition.");
             foreach (var partitionId in this.PartitionIds)
             {
-                var lastEvent = await DiscoverEndOfStreamForPartition(partitionId);
-                partitionOffsets.Add(partitionId, lastEvent.Item1);
-                TestUtility.Log($"Partition {partitionId} has last message with offset {lastEvent.Item1}");
+                var lastEvent = await this.EventHubClient.GetPartitionRuntimeInformationAsync(partitionId);
+                partitionOffsets.Add(partitionId, lastEvent.LastEnqueuedOffset);
+                TestUtility.Log($"Partition {partitionId} has last message with offset {lastEvent.LastEnqueuedOffset}");
             }
 
             // Now send a set of messages with different partition keys.

--- a/test/Microsoft.Azure.EventHubs.Tests/Processor/NegativeCases.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Processor/NegativeCases.cs
@@ -164,18 +164,19 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                 TestUtility.Log("Waiting for partition ownership to settle...");
                 await Task.Delay(TimeSpan.FromSeconds(5));
 
+                var client = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+
                 // Send first set of messages.
                 TestUtility.Log("Sending an event to each partition as the first set of messages.");
                 var sendTasks = new List<Task>();
                 foreach (var partitionId in PartitionIds)
                 {
-                    sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", TestUtility.EventHubsConnectionString));
+                    sendTasks.Add(TestUtility.SendToPartitionAsync(client, partitionId, $"{partitionId} event."));
                 }
                 await Task.WhenAll(sendTasks);
 
                 // Now send 1 poisoned message. This will fail one of the partition pumps.
                 TestUtility.Log($"Sending a poison event to partition {PartitionIds.First()}");
-                var client = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
                 var pSender = client.CreatePartitionSender(PartitionIds.First());
                 var ed = new EventData(Encoding.UTF8.GetBytes("This is poison message"));
                 ed.Properties[poisonMessageProperty] = true;
@@ -189,7 +190,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                 sendTasks.Clear();
                 foreach (var partitionId in PartitionIds)
                 {
-                    sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", TestUtility.EventHubsConnectionString));
+                    sendTasks.Add(TestUtility.SendToPartitionAsync(client, partitionId, $"{partitionId} event."));
                 }
                 await Task.WhenAll(sendTasks);
 

--- a/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
@@ -202,10 +202,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                 await Task.Delay(TimeSpan.FromSeconds(60));
 
                 TestUtility.Log("Sending an event to each partition");
+                var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
                 var sendTasks = new List<Task>();
                 foreach (var partitionId in PartitionIds)
                 {
-                    sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", TestUtility.EventHubsConnectionString));
+                    sendTasks.Add(TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event."));
                 }
                 await Task.WhenAll(sendTasks);
 
@@ -404,6 +405,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         {
             var customConsumerGroupName = "cgroup1";
 
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+
             // Generate a new lease container name that will be used through out the test.
             string leaseContainerName = Guid.NewGuid().ToString();
 
@@ -422,7 +425,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             {
                 // Create a receiver on the consumer group and try to receive.
                 // Receive call will fail if consumer group is missing.
-                var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
                 var receiver = ehClient.CreateReceiver(customConsumerGroupName, this.PartitionIds.First(), PartitionReceiver.StartOfStream);
                 await receiver.ReceiveAsync(1, TimeSpan.FromSeconds(5));
             }
@@ -479,7 +481,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                 var sendTasks = new List<Task>();
                 foreach (var partitionId in PartitionIds)
                 {
-                    sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", TestUtility.EventHubsConnectionString));
+                    sendTasks.Add(TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event."));
                 }
 
                 await Task.WhenAll(sendTasks);
@@ -925,15 +927,12 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                 await Task.Delay(5000);
 
                 TestUtility.Log($"Sending {totalNumberOfEventsToSend} event(s) to each partition");
+                var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
                 var sendTasks = new List<Task>();
                 foreach (var partitionId in PartitionIds)
                 {
-                    for (int i = 0; i < totalNumberOfEventsToSend; i++)
-                    {
-                        sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", TestUtility.EventHubsConnectionString));
-                    }
+                    sendTasks.Add(TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.", totalNumberOfEventsToSend));
                 }
-
                 await Task.WhenAll(sendTasks);
 
                 // Wait until all partitions are silent, i.e. no more events to receive.
@@ -959,20 +958,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
 
             return runResult;
-        }
-
-        protected async Task SendToPartitionAsync(string partitionId, string messageBody, string connectionString)
-        {
-            var eventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
-            try
-            {
-                var partitionSender = eventHubClient.CreatePartitionSender(partitionId);
-                await partitionSender.SendAsync(new EventData(Encoding.UTF8.GetBytes(messageBody)));
-            }
-            finally
-            {
-                await eventHubClient.CloseAsync();
-            }
         }
     }
 

--- a/test/Microsoft.Azure.EventHubs.Tests/TestUtility.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/TestUtility.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Azure.EventHubs.Tests
 {
     using System;
     using System.Diagnostics;
+    using System.Text;
+    using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs;
 
     static class TestUtility
@@ -50,6 +52,26 @@ namespace Microsoft.Azure.EventHubs.Tests
                 EntityPath = entityName
             };
             return connectionStringBuilder.ToString();
+        }
+
+        internal static async Task SendToPartitionAsync(EventHubClient ehClient, string partitionId, string messageBody, int numberOfMessages = 1)
+        {
+            TestUtility.Log($"Starting to send {numberOfMessages} to partition {partitionId}.");
+            var partitionSender = ehClient.CreatePartitionSender(partitionId);
+
+            for (int i = 0; i < numberOfMessages; i++)
+            {
+                await partitionSender.SendAsync(new EventData(Encoding.UTF8.GetBytes(messageBody)));
+            }
+
+            TestUtility.Log("Sends done.");
+        }
+
+        internal static async Task<Tuple<string, DateTime, string>> DiscoverEndOfStreamForPartitionAsync(EventHubClient ehClient, string partitionId)
+        {
+            TestUtility.Log($"Getting partition information for {partitionId}.");
+            var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+            return Tuple.Create(pInfo.LastEnqueuedOffset, pInfo.LastEnqueuedTimeUtc, pInfo.LastEnqueuedOffset);
         }
 
         internal static void Log(string message)


### PR DESCRIPTION
Close pump call might race with next Set call where client ends up with closed pump after reregistering.

This fix moves the Close call from pump task to SetReceiveHandler. 

The issue is reported and discussed at https://github.com/Azure/azure-event-hubs-dotnet/issues/173


## Description
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.