### PR TITLE
Using ConfigureAwait(false) to avoid context restoration

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/EventHubPartitionPump.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/EventHubPartitionPump.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.EventHubs.Processor
             if (this.PumpStatus == PartitionPumpStatus.OpenFailed)
             {
                 this.PumpStatus = PartitionPumpStatus.Closing;
-                await this.CleanUpClientsAsync();
+                await this.CleanUpClientsAsync().ConfigureAwait(false);
                 this.PumpStatus = PartitionPumpStatus.Closed;
             }
         }

--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionPump.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionPump.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.EventHubs.Processor
                 catch (Exception e)
                 {
                     ProcessorEventSource.Log.PartitionPumpInvokeProcessorEventsError(this.Host.Id, this.PartitionContext.PartitionId, e.ToString());
-                    await this.ProcessErrorAsync(e);
+                    await this.ProcessErrorAsync(e).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                             batchSize = receiveHandler.MaxBatchSize;
                         }
 
-                        receivedEvents = await this.ReceiveAsync(batchSize);
+                        receivedEvents = await this.ReceiveAsync(batchSize).ConfigureAwait(false);
                     }
                     catch (Exception e)
                     {
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                         await this.ReceiveHandlerProcessErrorAsync(e).ConfigureAwait(false);
 
                         // Avoid tight loop if Receieve call keeps faling.
-                        await Task.Delay(100);
+                        await Task.Delay(100).ConfigureAwait(false);
 
                         continue;
                     }

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpServiceClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpServiceClient.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.EventHubs.Amqp.Management
         async Task<RequestResponseAmqpLink> OpenLinkAsync(TimeSpan timeout)
         {
             ActiveClientRequestResponseLink activeClientLink = await OpenRequestResponseLinkAsync(
-                "svc", this.Address, null, AmqpServiceClient.RequiredClaims, timeout);
+                "svc", this.Address, null, AmqpServiceClient.RequiredClaims, timeout).ConfigureAwait(false);
             return activeClientLink.Link;
         }
 


### PR DESCRIPTION
## Description
When awaiting for an async method, by default context is captured and attempted to be restored. Since this is a library, it could be used from UI or non-UI code. W/o specifying .ConfigureAwait(false) there will be some overhead of attempting to restore the context. To avoid that, awaited code should explicitly specifying not to restore the context.

This checklist is used to make sure that common guidelines for a pull request are followed.

Related issue #41 #39 

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.