### PR TITLE
Close sender and receiver clients in web-sockets unit test.

### DIFF
--- a/test/Microsoft.Azure.EventHubs.Tests/Client/WebSocketTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/WebSocketTests.cs
@@ -63,18 +63,33 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             TestUtility.Log("Creating Event Hub client");
             var ehClient = EventHubClient.CreateFromConnectionString(webSocketConnString);
 
-            // Send single message
-            TestUtility.Log("Sending single event");
-            var sender = ehClient.CreatePartitionSender(targetPartitionId);
-            var eventData = new EventData(Encoding.UTF8.GetBytes("This event will be transported via web-sockets"));
-            await sender.SendAsync(eventData);
+            PartitionSender sender = null;
+            try
+            {
+                // Send single message
+                TestUtility.Log("Sending single event");
+                sender = ehClient.CreatePartitionSender(targetPartitionId);
+                var eventData = new EventData(Encoding.UTF8.GetBytes("This event will be transported via web-sockets"));
+                await sender.SendAsync(eventData);
+            }
+            finally
+            {
+                await sender?.CloseAsync();
+            }
 
-            // Receive single message.
-            TestUtility.Log("Receiving single event");
-            var receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartitionId, PartitionReceiver.StartOfStream);
-            var msg = await receiver.ReceiveAsync(1);
-
-            Assert.True(msg != null, $"Failed to receive single event from partition {targetPartitionId}");
+            PartitionReceiver receiver = null;
+            try
+            {
+                // Receive single message.
+                TestUtility.Log("Receiving single event");
+                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartitionId, PartitionReceiver.StartOfStream);
+                var msg = await receiver.ReceiveAsync(1);
+                Assert.True(msg != null, $"Failed to receive single event from partition {targetPartitionId}");
+            }
+            finally
+            {
+                await receiver?.CloseAsync();
+            }
         }
     }
 }


### PR DESCRIPTION
Missed to close sender and receiver at the end of new unit test which is causing intermittent failures in other tests when max receiver limit is hit.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.