### PR TITLE
Client entities should inherit retry policy from parent client.

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                                 throw new AmqpException(rejected.Error);
                             }
 
-                            this.EventHubClient.RetryPolicy.ResetRetryCount(this.ClientId);
+                            this.RetryPolicy.ResetRetryCount(this.ClientId);
                         }
                         catch (AmqpException amqpException)
                         {
@@ -85,8 +85,8 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     catch (Exception ex)
                     {
                         // Evaluate retry condition?
-                        this.EventHubClient.RetryPolicy.IncrementRetryCount(this.ClientId);
-                        TimeSpan? retryInterval = this.EventHubClient.RetryPolicy.GetNextRetryInterval(this.ClientId, ex, timeoutHelper.RemainingTime());
+                        this.RetryPolicy.IncrementRetryCount(this.ClientId);
+                        TimeSpan? retryInterval = this.RetryPolicy.GetNextRetryInterval(this.ClientId, ex, timeoutHelper.RemainingTime());
                         if (retryInterval != null)
                         {
                             await Task.Delay(retryInterval.Value).ConfigureAwait(false);

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                             throw receiveLink.TerminalException;
                         }
 
-                        this.EventHubClient.RetryPolicy.ResetRetryCount(this.ClientId);
+                        this.RetryPolicy.ResetRetryCount(this.ClientId);
 
                         if (hasMessages && amqpMessages != null)
                         {
@@ -101,8 +101,8 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 catch (Exception ex)
                 {
                     // Evaluate retry condition?
-                    this.EventHubClient.RetryPolicy.IncrementRetryCount(this.ClientId);
-                    TimeSpan? retryInterval = this.EventHubClient.RetryPolicy.GetNextRetryInterval(this.ClientId, ex, timeoutHelper.RemainingTime());
+                    this.RetryPolicy.IncrementRetryCount(this.ClientId);
+                    TimeSpan? retryInterval = this.RetryPolicy.GetNextRetryInterval(this.ClientId, ex, timeoutHelper.RemainingTime());
                     if (retryInterval != null)
                     {
                         await Task.Delay(retryInterval.Value).ConfigureAwait(false);

--- a/src/Microsoft.Azure.EventHubs/EventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/EventDataSender.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.EventHubs
         {
             this.EventHubClient = eventHubClient;
             this.PartitionId = partitionId;
+            this.RetryPolicy = eventHubClient.RetryPolicy.Clone();
         }
 
         protected EventHubClient EventHubClient { get; }

--- a/src/Microsoft.Azure.EventHubs/EventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/EventHubClient.cs
@@ -476,5 +476,17 @@ namespace Microsoft.Azure.EventHubs
         /// <summary></summary>
         /// <returns></returns>
         protected abstract Task OnCloseAsync();
+
+        /// <summary>
+        /// Handle retry policy updates here.
+        /// </summary>
+        protected override void OnRetryPolicyUpdate()
+        {
+            // Propagate retry policy updates to inner sender if there is any.
+            if (this.innerSender != null)
+            {
+                this.innerSender.RetryPolicy = this.RetryPolicy.Clone();
+            }
+        }
     }
 }

--- a/src/Microsoft.Azure.EventHubs/PartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/PartitionReceiver.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Azure.EventHubs
             this.StartTime = startTime;
             this.PrefetchCount = DefaultPrefetchCount;
             this.Epoch = epoch;
+            this.RetryPolicy = eventHubClient.RetryPolicy.Clone();
 
             EventHubsEventSource.Log.ClientCreated(this.ClientId, this.FormatTraceDetails());
         }

--- a/src/Microsoft.Azure.EventHubs/Primitives/ClientEntity.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/ClientEntity.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Azure.EventHubs
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -13,6 +14,8 @@ namespace Microsoft.Azure.EventHubs
     public abstract class ClientEntity
     {
         static int nextId;
+
+        RetryPolicy retryPolicy;
 
         /// <summary></summary>
         /// <param name="clientId"></param>
@@ -32,7 +35,19 @@ namespace Microsoft.Azure.EventHubs
         /// <summary>
         /// Gets the <see cref="RetryPolicy.RetryPolicy"/> for the ClientEntity.
         /// </summary>
-        public RetryPolicy RetryPolicy { get; set; }
+        public RetryPolicy RetryPolicy
+        {
+            get
+            {
+                return this.retryPolicy;
+            }
+
+            set
+            {
+                this.retryPolicy = value;
+                this.OnRetryPolicyUpdate();
+            }
+        }
 
         /// <summary>
         /// Closes the ClientEntity.
@@ -53,6 +68,14 @@ namespace Microsoft.Azure.EventHubs
         protected static long GetNextId()
         {
             return Interlocked.Increment(ref nextId);
+        }
+
+        /// <summary>
+        /// Derived entity to override for retry policy updates.
+        /// </summary>
+        protected virtual void OnRetryPolicyUpdate()
+        {
+            // NOOP
         }
     }
 }

--- a/src/Microsoft.Azure.EventHubs/Primitives/RetryExponential.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/RetryExponential.cs
@@ -74,5 +74,12 @@ namespace Microsoft.Azure.EventHubs
 
             return (Math.Log(deltaBackoff) / Math.Log(this.maximumRetryCount));
         }
+
+        /// <summary>Creates a new copy of this instance.</summary>
+        /// <returns>The created new copy of this instance.</returns>
+        public override RetryPolicy Clone()
+        {
+            return new RetryExponential(this.minimumBackoff, this.maximumBackoff, this.maximumRetryCount);
+        }
     }
 }

--- a/src/Microsoft.Azure.EventHubs/Primitives/RetryPolicy.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/RetryPolicy.cs
@@ -144,5 +144,9 @@ namespace Microsoft.Azure.EventHubs
 
             return retryAfter;
         }
+
+        /// <summary>Creates a new copy of the current <see cref="RetryPolicy" /> and clones it into a new instance.</summary>
+        /// <returns>A new copy of <see cref="RetryPolicy" />.</returns>
+        public abstract RetryPolicy Clone();
     }
 }

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/RetryTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/RetryTests.cs
@@ -102,9 +102,31 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             Assert.True(newRetryInterval == null);
         }
 
+        [Fact]
+        [DisplayTestMethodName]
+        void ChildEntityShouldInheritRetryPolicyFromParent()
+        {
+            var testMaxRetryCount = 99;
+
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            ehClient.RetryPolicy = new RetryPolicyCustom(testMaxRetryCount);
+
+            // Validate partition sender inherits.
+            var sender = ehClient.CreateEventSender("0");
+            Assert.True(sender.RetryPolicy is RetryPolicyCustom, "Sender failed to inherit parent client's RetryPolicy setting.");
+            Assert.True((sender.RetryPolicy as RetryPolicyCustom).maximumRetryCount == testMaxRetryCount,
+                $"Retry policy on the sender shows testMaxRetryCount as {(sender.RetryPolicy as RetryPolicyCustom).maximumRetryCount}");
+
+            // Validate partition receiver inherits.
+            var receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", PartitionReceiver.StartOfStream);
+            Assert.True(receiver.RetryPolicy is RetryPolicyCustom, "Receiver failed to inherit parent client's RetryPolicy setting.");
+            Assert.True((receiver.RetryPolicy as RetryPolicyCustom).maximumRetryCount == testMaxRetryCount,
+                $"Retry policy on the receiver shows testMaxRetryCount as {(sender.RetryPolicy as RetryPolicyCustom).maximumRetryCount}");
+        }
+
         public sealed class RetryPolicyCustom : RetryPolicy
         {
-            readonly int maximumRetryCount;
+            public readonly int maximumRetryCount;
 
             public RetryPolicyCustom(int maximumRetryCount)
             {
@@ -127,6 +149,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 TimeSpan retryAfter = TimeSpan.FromSeconds(1 + currentRetryCount);
 
                 return retryAfter;
+            }
+
+            public override RetryPolicy Clone()
+            {
+                return new RetryPolicyCustom(this.maximumRetryCount);
             }
         }
     }

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/RetryTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/RetryTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             var receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", PartitionReceiver.StartOfStream);
             Assert.True(receiver.RetryPolicy is RetryPolicyCustom, "Receiver failed to inherit parent client's RetryPolicy setting.");
             Assert.True((receiver.RetryPolicy as RetryPolicyCustom).maximumRetryCount == testMaxRetryCount,
-                $"Retry policy on the receiver shows testMaxRetryCount as {(sender.RetryPolicy as RetryPolicyCustom).maximumRetryCount}");
+                $"Retry policy on the receiver shows testMaxRetryCount as {(receiver.RetryPolicy as RetryPolicyCustom).maximumRetryCount}");
         }
 
         public sealed class RetryPolicyCustom : RetryPolicy


### PR DESCRIPTION
This change allows retry policy to be specialized on child entities like senders and receivers. For example with this change, when both senders and receivers are created from the same client, senders can have RetryPolicyExponential while receivers have NoRetry. 

Change aligns .Net Standard client with .Net client's retry policy.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.