### PR TITLE
Fix EventHubsConnectionStringBuilder ctor crash with SharedAccessSignature

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.EventHubs
             TimeSpan operationTimeout)
             : this(endpointAddress, entityPath, operationTimeout)
         {
-            if (string.IsNullOrWhiteSpace(SharedAccessSignature))
+            if (string.IsNullOrWhiteSpace(sharedAccessSignature))
             {
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(nameof(sharedAccessSignature));
             }


### PR DESCRIPTION
When supplying SharedAccessSignature as a parameter

## Description
Fixes #288 (https://github.com/Azure/azure-event-hubs-dotnet/issues/218)

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.