### PR TITLE
Fix EventHubsConnectionStringBuilder's SharedAccessSignature overload.

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.EventHubs
             TimeSpan operationTimeout)
             : this(endpointAddress, entityPath, operationTimeout)
         {
-            if (string.IsNullOrWhiteSpace(SharedAccessSignature))
+            if (string.IsNullOrWhiteSpace(sharedAccessSignature))
             {
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(nameof(sharedAccessSignature));
             }

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/ConnectionStringBuilderTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/ConnectionStringBuilderTests.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 {
     using System;
     using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class ConnectionStringBuilderTests
@@ -110,6 +112,45 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                     throw new InvalidOperationException("ToString() should have failed");
                 });
             }
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task UseSharedAccessSignatureApi()
+        {
+            // Generate shared access token.
+            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
+            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(csb.SasKeyName, csb.SasKey);
+            var token = await tokenProvider.GetTokenAsync(csb.Endpoint.ToString(), "Send,Receive", TimeSpan.FromSeconds(120));
+            var sharedAccessSignature = token.TokenValue.ToString();
+
+            // Create connection string builder by SharedAccessSignature overload.
+            var csbNew = new EventHubsConnectionStringBuilder(csb.Endpoint, csb.EntityPath, sharedAccessSignature, TimeSpan.FromSeconds(60));
+
+            // Create new client with updated connection string.
+            var ehClient = EventHubClient.CreateFromConnectionString(csbNew.ToString());
+
+            // Send one event
+            TestUtility.Log($"Sending one message.");
+            var ehSender = ehClient.CreatePartitionSender("0");
+            var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!"));
+            await ehSender.SendAsync(eventData);
+
+            // Receive event.
+            TestUtility.Log($"Receiving one message.");
+            var ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", PartitionReceiver.StartOfStream);
+            var msg = await ehReceiver.ReceiveAsync(1);
+            Assert.True(msg != null, "Failed to receive message.");
+
+            // Get EH runtime information.
+            TestUtility.Log($"Getting Event Hub runtime information.");
+            var ehInfo = await ehClient.GetRuntimeInformationAsync();
+            Assert.True(ehInfo != null, "Failed to get runtime information.");
+
+            // Get EH partition runtime information.
+            TestUtility.Log($"Getting Event Hub partition '0' runtime information.");
+            var partitionInfo = await ehClient.GetPartitionRuntimeInformationAsync("0");
+            Assert.True(ehInfo != null, "Failed to get runtime partition information.");
         }
     }
 }


### PR DESCRIPTION
Fix EventHubsConnectionStringBuilder's SharedAccessSignature overload. Current implementation throws NulRef although valid signature string is provided.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.