### PR TITLE
Fixing empty offset from no-receive partition lease.

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.EventHubs.Processor
         {
     	    AzureBlobLease lease = (AzureBlobLease)await GetLeaseAsync(partitionId).ConfigureAwait(false);
             Checkpoint checkpoint = null;
-            if (lease?.Offset != null)
+            if (lease != null && !string.IsNullOrEmpty(lease.Offset))
             {
                 checkpoint = new Checkpoint(partitionId)
                 {

--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionContext.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionContext.cs
@@ -99,9 +99,8 @@ namespace Microsoft.Azure.EventHubs.Processor
             if (startingCheckpoint == null)
             {
                 // No checkpoint was ever stored. Use the initialOffsetProvider instead.
-                Func<string, EventPosition> initialOffsetProvider = this.host.EventProcessorOptions.InitialOffsetProvider;
                 ProcessorEventSource.Log.PartitionPumpInfo(this.host.Id, this.PartitionId, "Calling user-provided initial offset provider");
-                eventPosition = initialOffsetProvider(this.PartitionId);
+                eventPosition = this.host.EventProcessorOptions.InitialOffsetProvider(this.PartitionId);
                 ProcessorEventSource.Log.PartitionPumpInfo(this.host.Id, this.PartitionId, $"Initial Position Provider. Offset:{eventPosition.Offset}, SequenceNumber:{eventPosition.SequenceNumber}, DateTime:{eventPosition.EnqueuedTimeUtc}");
             }
             else


### PR DESCRIPTION
Lease might have empty offset data stored if there were no events on the partitions. This fix handles such cases.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.