### PR TITLE
Notify partitionId in the error callback if lease call fails.

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -195,9 +195,11 @@ namespace Microsoft.Azure.EventHubs.Processor
                 int ourLeaseCount = 0;
                 foreach (Task<Lease> getLeaseTask in gettingAllLeases)
                 {
+                    Lease possibleLease = null;
+
                     try
                     {
-                        Lease possibleLease = await getLeaseTask.ConfigureAwait(false);
+                        possibleLease = await getLeaseTask.ConfigureAwait(false);
                         allLeases[possibleLease.PartitionId] = possibleLease;
                         if (await possibleLease.IsExpired().ConfigureAwait(false))
                         {
@@ -237,7 +239,7 @@ namespace Microsoft.Azure.EventHubs.Processor
                     catch (Exception e)
                     {
                         ProcessorEventSource.Log.EventProcessorHostWarning(this.host.Id, "Failure during getting/acquiring/renewing lease, skipping", e.ToString());
-                        this.host.EventProcessorOptions.NotifyOfException(this.host.HostName, "N/A", e, EventProcessorHostActionStrings.CheckingLeases);
+                        this.host.EventProcessorOptions.NotifyOfException(this.host.HostName, possibleLease?.PartitionId ?? "N/A", e, EventProcessorHostActionStrings.CheckingLeases);
                     }
                 }
 


### PR DESCRIPTION
EPH client isn't providing partitionId when storage call fails on renew or acquire call. This fix addresses that issue.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.