### PR TITLE
Fix event data batch size miscalculation

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.EventHubs.Processor
                 try
                 {
                     eventHubClient = EventHubClient.CreateFromConnectionString(this.host.EventHubConnectionString);
+                    eventHubClient.WebProxy = this.host.EventProcessorOptions.WebProxy;
                     var runtimeInfo = await eventHubClient.GetRuntimeInformationAsync().ConfigureAwait(false);
                     this.partitionIds = runtimeInfo.PartitionIds.ToList();
                 }

--- a/src/Microsoft.Azure.EventHubs/EventDataBatch.cs
+++ b/src/Microsoft.Azure.EventHubs/EventDataBatch.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Azure.EventHubs
             this.PartitionKey = partitionKey;
             this.maxSize = Math.Min(maxSizeInBytes, MaxSizeLimit);
             this.eventDataList = new List<EventData>();
-            this.currentSize = (maxSizeInBytes / 65536) * 1024;    // reserve 1KB for every 64KB
         }
 
         /// <summary>Gets the current event count in the batch.</summary>
@@ -82,7 +81,9 @@ namespace Microsoft.Azure.EventHubs
             var amqpMessage = AmqpMessageConverter.EventDataToAmqpMessage(eventData);
             AmqpMessageConverter.UpdateAmqpMessagePartitionKey(amqpMessage, this.PartitionKey);
             eventData.AmqpMessage = amqpMessage;
-            return eventData.AmqpMessage.SerializedMessageSize;
+
+            // +5 for data section overhead
+            return eventData.AmqpMessage.SerializedMessageSize + 5;
         }
 
         /// <summary>

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/DataBatchTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/DataBatchTests.cs
@@ -22,6 +22,17 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 
         /// <summary>
+        /// Utilizes EventDataBatch to send small messages.
+        /// WE try to catch any overhead miscalculation here.
+        /// </summary>
+        [Fact]
+        [DisplayTestMethodName]
+        async Task BatchSenderSmallMessages()
+        {
+            await SendWithEventDataBatch(maxPayloadSize: 8, minimumNumberOfMessagesToSend: 50000);
+        }
+
+        /// <summary>
         /// Utilizes EventDataBatch to send messages as the messages are batched up to max batch size.
         /// This unit test sends with partition key.
         /// </summary>
@@ -75,10 +86,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             });
         }
 
-        protected async Task SendWithEventDataBatch(string partitionKey = null)
+        protected async Task SendWithEventDataBatch(
+            string partitionKey = null,
+            int maxPayloadSize = 1024,
+            int minimumNumberOfMessagesToSend = 1000)
         {
-            const int MinimumNumberOfMessagesToSend = 1000;
-
             var receivers = new List<PartitionReceiver>();
 
             // Create partition receivers starting from the end of the stream.
@@ -121,7 +133,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 do
                 {
                     // Send random body size.
-                    var ed = new EventData(new byte[rnd.Next(0, 1024)]);
+                    var ed = new EventData(new byte[rnd.Next(0, maxPayloadSize)]);
                     if (!batcher.TryAdd(ed))
                     {
                         await this.EventHubClient.SendAsync(batcher);
@@ -136,7 +148,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                             PartitionKey = partitionKey
                         });
                     }
-                } while (totalSent < MinimumNumberOfMessagesToSend);
+                } while (totalSent < minimumNumberOfMessagesToSend);
 
                 // Send the rest of the batch if any.
                 if (batcher.Count > 0)


### PR DESCRIPTION
This fix addresses a batch size miscalculation issue which reveled when very small messages batched. Adding a test to make sure this holds well.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.