### PR TITLE
Always use default timeout for AMQP sesssion create.

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventDataSender.cs
@@ -58,7 +58,9 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     {
                         try
                         {
-                            var amqpLink = await this.SendLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                            // Always use default timeout for AMQP sesssion.
+                            var amqpLink = await this.SendLinkManager.GetOrCreateAsync(
+                                TimeSpan.FromSeconds(AmqpClientConstants.AmqpSessionTimeoutInSeconds)).ConfigureAwait(false);
                             if (amqpLink.Settings.MaxMessageSize.HasValue)
                             {
                                 ulong size = (ulong)amqpMessage.SerializedMessageSize;
@@ -111,10 +113,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
         {
             var amqpEventHubClient = ((AmqpEventHubClient)this.EventHubClient);
 
-            // We won't use remaining timeout during create session call.
-            // For large or small operation timeout values using remaining time won't make any sense.
-            var timeoutHelper = new TimeoutHelper(TimeSpan.FromSeconds(AmqpClientConstants.AmqpSessionTimeoutInSeconds));
-
+            var timeoutHelper = new TimeoutHelper(timeout);
             AmqpConnection connection = await amqpEventHubClient.ConnectionManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             // Authenticate over CBS

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -175,8 +175,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
         {
             var amqpEventHubClient = ((AmqpEventHubClient)this.EventHubClient);
 
-            // We won't use remaining timeout during create session call.
-            // For large or small operation timeout values using remaining time won't make any sense.
             var timeoutHelper = new TimeoutHelper(timeout);
             AmqpConnection connection = await amqpEventHubClient.ConnectionManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -62,7 +62,11 @@ namespace Microsoft.Azure.EventHubs.Amqp
                 {
                     try
                     {
-                        ReceivingAmqpLink receiveLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                        // Always use default timeout for AMQP sesssion.
+                        ReceivingAmqpLink receiveLink =
+                            await this.ReceiveLinkManager.GetOrCreateAsync(
+                                TimeSpan.FromSeconds(AmqpClientConstants.AmqpSessionTimeoutInSeconds)).ConfigureAwait(false);
+
                         IEnumerable<AmqpMessage> amqpMessages = null;
                         bool hasMessages = await Task.Factory.FromAsync(
                             (c, s) => receiveLink.BeginReceiveMessages(maxMessageCount, timeoutHelper.RemainingTime(), c, s),
@@ -173,8 +177,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
             // We won't use remaining timeout during create session call.
             // For large or small operation timeout values using remaining time won't make any sense.
-            var timeoutHelper = new TimeoutHelper(TimeSpan.FromSeconds(AmqpClientConstants.AmqpSessionTimeoutInSeconds));
-
+            var timeoutHelper = new TimeoutHelper(timeout);
             AmqpConnection connection = await amqpEventHubClient.ConnectionManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             // Authenticate over CBS

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpServiceClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpServiceClient.cs
@@ -57,13 +57,14 @@ namespace Microsoft.Azure.EventHubs.Amqp.Management
 
         public async Task<EventHubRuntimeInformation> GetRuntimeInformationAsync()
         {
-            RequestResponseAmqpLink requestLink = await this.link.GetOrCreateAsync(TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+            RequestResponseAmqpLink requestLink = await this.link.GetOrCreateAsync(
+                TimeSpan.FromSeconds(AmqpClientConstants.AmqpSessionTimeoutInSeconds)).ConfigureAwait(false);
 
             // Create request and attach token.
             var request = this.CreateGetRuntimeInformationRequest();
             request.ApplicationProperties.Map[AmqpClientConstants.ManagementSecurityTokenKey] = await GetTokenString().ConfigureAwait(false);
 
-            var response = await requestLink.RequestAsync(request, TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+            var response = await requestLink.RequestAsync(request, eventHubClient.ConnectionStringBuilder.OperationTimeout).ConfigureAwait(false);
             int statusCode = (int)response.ApplicationProperties.Map[AmqpClientConstants.ResponseStatusCode];
             string statusDescription = (string)response.ApplicationProperties.Map[AmqpClientConstants.ResponseStatusDescription];
             if (statusCode != (int)AmqpResponseStatusCode.Accepted && statusCode != (int)AmqpResponseStatusCode.OK)
@@ -96,13 +97,14 @@ namespace Microsoft.Azure.EventHubs.Amqp.Management
 
         public async Task<EventHubPartitionRuntimeInformation> GetPartitionRuntimeInformationAsync(string partitionId)
         {
-            RequestResponseAmqpLink requestLink = await this.link.GetOrCreateAsync(TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+            RequestResponseAmqpLink requestLink = await this.link.GetOrCreateAsync(
+                TimeSpan.FromSeconds(AmqpClientConstants.AmqpSessionTimeoutInSeconds)).ConfigureAwait(false);
 
             // Create request and attach token.
             var request = this.CreateGetPartitionRuntimeInformationRequest(partitionId);
             request.ApplicationProperties.Map[AmqpClientConstants.ManagementSecurityTokenKey] = await GetTokenString().ConfigureAwait(false);
 
-            var response = await requestLink.RequestAsync(request, TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+            var response = await requestLink.RequestAsync(request, eventHubClient.ConnectionStringBuilder.OperationTimeout).ConfigureAwait(false);
             int statusCode = (int)response.ApplicationProperties.Map[AmqpClientConstants.ResponseStatusCode];
             string statusDescription = (string)response.ApplicationProperties.Map[AmqpClientConstants.ResponseStatusDescription];
             if (statusCode != (int)AmqpResponseStatusCode.Accepted && statusCode != (int)AmqpResponseStatusCode.OK)


### PR DESCRIPTION
Move AmqpClientConstants.AmqpSessionTimeoutInSeconds to Receive call. This way default timeout will be respected through the AMQP session create stack.

+ Fixing timeouts used in AMQP management calls.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.