### PR TITLE
Fix correlation id not received from IotHub EH endpoint

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpMessageConverter.cs
@@ -214,6 +214,39 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     }
                 }
             }
+
+            if ((sections & SectionFlag.Properties) != 0)
+            {
+                if (data.SystemProperties == null)
+                {
+                    data.SystemProperties = new EventData.SystemPropertiesCollection();
+                }
+
+                if (amqpMessage.Properties != null)
+                {
+                    AddFieldToSystemProperty(amqpMessage.Properties.MessageId != null, data.SystemProperties, Properties.MessageIdName, amqpMessage.Properties.MessageId);
+                    AddFieldToSystemProperty(amqpMessage.Properties.UserId.Array != null, data.SystemProperties, Properties.UserIdName, amqpMessage.Properties.UserId);
+                    AddFieldToSystemProperty(amqpMessage.Properties.To != null, data.SystemProperties, Properties.ToName, amqpMessage.Properties.To);
+                    AddFieldToSystemProperty(amqpMessage.Properties.Subject != null, data.SystemProperties, Properties.SubjectName, amqpMessage.Properties.Subject);
+                    AddFieldToSystemProperty(amqpMessage.Properties.ReplyTo != null, data.SystemProperties, Properties.ReplyToName, amqpMessage.Properties.ReplyTo);
+                    AddFieldToSystemProperty(amqpMessage.Properties.CorrelationId != null, data.SystemProperties, Properties.CorrelationIdName, amqpMessage.Properties.CorrelationId);
+                    AddFieldToSystemProperty(amqpMessage.Properties.ContentType.Value != null, data.SystemProperties, Properties.ContentTypeName, amqpMessage.Properties.ContentType);
+                    AddFieldToSystemProperty(amqpMessage.Properties.ContentEncoding.Value != null, data.SystemProperties, Properties.ContentEncodingName, amqpMessage.Properties.ContentEncoding);
+                    AddFieldToSystemProperty(amqpMessage.Properties.AbsoluteExpiryTime != null, data.SystemProperties, Properties.AbsoluteExpiryTimeName, amqpMessage.Properties.AbsoluteExpiryTime);
+                    AddFieldToSystemProperty(amqpMessage.Properties.CreationTime != null, data.SystemProperties, Properties.CreationTimeName, amqpMessage.Properties.CreationTime);
+                    AddFieldToSystemProperty(amqpMessage.Properties.GroupId != null, data.SystemProperties, Properties.GroupIdName, amqpMessage.Properties.GroupId);
+                    AddFieldToSystemProperty(amqpMessage.Properties.GroupSequence != null, data.SystemProperties, Properties.GroupSequenceName, amqpMessage.Properties.GroupSequence);
+                    AddFieldToSystemProperty(amqpMessage.Properties.ReplyToGroupId != null, data.SystemProperties, Properties.ReplyToGroupIdName, amqpMessage.Properties.ReplyToGroupId);
+                }
+            }
+        }
+
+        private static void AddFieldToSystemProperty(bool condition, EventData.SystemPropertiesCollection systemProperties, string propertyName, object value)
+        {
+            if (condition)
+            {
+                systemProperties[propertyName] = value;
+            }
         }
 
         static ArraySegment<byte> StreamToBytes(Stream stream)

--- a/test/Microsoft.Azure.EventHubs.Tests/Amqp/AmqpMEssageCoverterTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Amqp/AmqpMEssageCoverterTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs.Tests.Amqp
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Azure.Amqp;
+    using Microsoft.Azure.Amqp.Framing;
+    using Microsoft.Azure.EventHubs.Amqp;
+    using Xunit;
+
+    public class AmqpMessageCoverterTests
+    {
+        /// <summary>
+        /// Validating that properties from an Amqp message are forwarded to EventData SystemProperties 
+        /// </summary>
+        [Fact]
+        [DisplayTestMethodName]
+        void UpdateEventDataHeaderAndPropertiesReceiveCorrelationIdAndCopyItsValueToEventData()
+        {
+            // Arrange
+
+            // the following simulates a message's round trip from client to broker to client
+            var message = AmqpMessage.Create(new MemoryStream(new byte[12]), true);
+            AddSection(message, SectionFlag.Properties);
+            // serialize - send the message on client side
+            ArraySegment<byte>[] buffers = ReadMessagePayLoad(message, 71);
+            EventData eventData;
+            
+            // Act 
+            eventData = AmqpMessageConverter.AmqpMessageToEventData(message);
+
+            // Assert
+            Assert.NotNull(eventData);
+            Assert.NotNull(eventData.SystemProperties);
+            Assert.NotNull(eventData.SystemProperties[Properties.CorrelationIdName]);
+            Assert.Equal("42", eventData.SystemProperties[Properties.CorrelationIdName].ToString());
+        }
+
+        // for more information please take a look at https://github.com/Azure/azure-amqp/blob/339708e6390447004c3eec8ae28e6577199a4328/test/TestCases/AmqpMessageTests.cs#L160
+        static void AddSection(AmqpMessage message, SectionFlag sections)
+        {
+            if ((sections & SectionFlag.Properties) != 0)
+            {
+                message.Properties.CorrelationId = "42";
+            }
+        }
+
+        static ArraySegment<byte>[] ReadMessagePayLoad(AmqpMessage message, int payloadSize)
+        {
+            List<ArraySegment<byte>> buffers = new List<ArraySegment<byte>>();
+            bool more = true;
+            while (more)
+            {
+                ArraySegment<byte>[] messageBuffers = message.GetPayload(payloadSize, out more);
+                if (messageBuffers != null)
+                {
+                    foreach (var segment in messageBuffers) { message.CompletePayload(segment.Count); }
+                    buffers.AddRange(messageBuffers);
+                }
+            }
+
+            return buffers.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
copy properties from an amqp message into the the event data system
properties collection when updating the event data headers and
properites.

  - follow the code style from Azure EH Amqp dotnet: https://github.com/Azure/azure-amqp/blob/9b421a7ebee725196507b64d1feab8950a079859/Microsoft.Azure.Amqp/Amqp/Framing/Properties.cs#L65
  - add some coverage that helps to test and understand how to reprod

resolved: #242

## Description
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [X] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
- [X] The code builds without any errors.