### PR TITLE
Create EventHubsTimeoutException for consistency

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpExceptionHelper.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
         {
             if (string.Equals(condition, AmqpClientConstants.TimeoutError.Value))
             {
-                return new TimeoutException(message);
+                return new EventHubsTimeoutException(message);
             }
             else if (string.Equals(condition, AmqpErrorCode.NotFound.Value))
             {

--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpPartitionReceiver.cs
@@ -112,9 +112,9 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     }
                     else
                     {
-                        // Handle System.TimeoutException explicitly.
-                        // We don't really want to to throw TimeoutException on this call.
-                        if (ex is TimeoutException)
+                        // Handle EventHubsTimeoutException explicitly.
+                        // We don't really want to to throw EventHubsTimeoutException on this call.
+                        if (ex is EventHubsTimeoutException)
                         {
                             break;
                         }

--- a/src/Microsoft.Azure.EventHubs/Primitives/EventHubsTimeoutException.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/EventHubsTimeoutException.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs
+{
+    using System;
+
+    /// <summary>
+    ///     The exception that is thrown when a time out is encountered.  Callers retry the operation.
+    /// </summary>
+    public class EventHubsTimeoutException : EventHubsException
+    {
+        internal EventHubsTimeoutException(string message) : this(message, null)
+        {
+        }
+
+        /// <summary>
+        ///     
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
+        internal EventHubsTimeoutException(string message, Exception innerException)
+            : base(true, message, innerException)
+        {
+        }
+    }
+}

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/TimeoutTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/TimeoutTests.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 
         /// <summary>
-        /// Small receive timeout should not throw System.TimeoutException. 
-        /// TimeoutException should be returned as NULL to the awaiting client.
+        /// Small receive timeout should not throw EventHubsTimeoutException. 
+        /// EventHubsTimeoutException should be returned as NULL to the awaiting client.
         /// </summary>
         /// <returns></returns>
         [Fact]


### PR DESCRIPTION
## Description
For consistency I've craeted EventHubsTimeOutException Trasient as true as default.
Reference. https://github.com/Azure/azure-event-hubs-dotnet/issues/176

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.