### PR TITLE
Fix Build for Plugin_without_ShouldContinueOnException_should_throw Failing

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
@@ -66,7 +66,18 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
         internal override EventDataSender OnCreateEventSender(string partitionId)
         {
-            return new AmqpEventDataSender(this, partitionId);
+            var sender = new AmqpEventDataSender(this, partitionId);
+
+            if (this.RegisteredPlugins.Count >= 1)
+            {
+                // register all the plugins
+                foreach (var plugin in this.RegisteredPlugins)
+                {
+                    sender.RegisterPlugin(plugin.Value);
+                }
+            }
+
+            return sender;
         }
 
         protected override PartitionReceiver OnCreateReceiver(

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/PluginTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/PluginTests.cs
@@ -83,7 +83,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
                 this.EventHubClient.RegisterPlugin(plugin);
                 var testEvent = new EventData(Encoding.UTF8.GetBytes("Test message"));
-                await this.EventHubClient.SendAsync(testEvent);
                 await Assert.ThrowsAsync<NotImplementedException>(() => this.EventHubClient.SendAsync(testEvent));
             }
             finally


### PR DESCRIPTION
## Description
@serkantkaraca for this
https://github.com/Azure/azure-event-hubs-dotnet/pull/324

Here the client create other send and lose the Plugins, 
I've copy them in the method you can see in the change, what do you think of this approach, any other better way to do that ? 

https://github.com/Azure/azure-event-hubs-dotnet/blob/4fc6c60288c1c38dc89aca8424ae2a4c24ecfe25/src/Microsoft.Azure.EventHubs/EventHubClient.cs#L51


This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.