### PR TITLE
Using Lazy instead of static initialization for ExceptionUtility 

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Primitives/Fx.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/Fx.cs
@@ -3,22 +3,18 @@
 
 namespace Microsoft.Azure.EventHubs
 {
+    using System;
     using System.Diagnostics;
 
     static class Fx
     {
-        static ExceptionUtility exceptionUtility;
+        static readonly Lazy<ExceptionUtility> exceptionUtility = new Lazy<ExceptionUtility>(() => new ExceptionUtility());
 
         public static ExceptionUtility Exception
         {
             get
             {
-                if (exceptionUtility == null)
-                {
-                    exceptionUtility = new ExceptionUtility();
-                }
-
-                return exceptionUtility;
+                return exceptionUtility.Value;
             }
         }
 

--- a/src/Microsoft.Azure.EventHubs/Primitives/Fx.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/Fx.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.EventHubs
 
     static class Fx
     {
-        static readonly Lazy<ExceptionUtility> exceptionUtility = new Lazy<ExceptionUtility>(() => new ExceptionUtility());
+        private static readonly Lazy<ExceptionUtility> exceptionUtility = new Lazy<ExceptionUtility>();
 
         public static ExceptionUtility Exception
         {


### PR DESCRIPTION
## Description
Very small PR to change the static initialization for  `ExceptionUtility` to a Lazy 
https://docs.microsoft.com/en-us/dotnet/framework/performance/lazy-initialization

I think it's not necessary a thread guarantee for this but it won't harm and the package won't lose anything using it.

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.

