### PR TITLE
Nullfy Task when The Stop is complete

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -76,6 +76,9 @@ namespace Microsoft.Azure.EventHubs.Processor
             {
                 await localRunTask.ConfigureAwait(false);
             }
+
+            // once it is closed let's reset the task
+            this.runTask = null;
         }
 
         async Task RunAsync()


### PR DESCRIPTION
## Description
@serkantkaraca well as I was guessing it is working .

However I wanted to test and it was quite difficult first because Partition manager is internal,
I've managed to configure only for debing and testing `InternalVisibleTo` but `EventProcessorHost` is a `sealed` class and cannot be mocked.

I'll push a new PR after a few working to propose moving ` EventProcessorHost` to be an interface we can add tons of testing if so.

Thanks as always :) 

PD : this resolve this issue https://github.com/Azure/azure-event-hubs-dotnet/issues/340

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.