### PR TITLE
Replace Locks in AmqpEventHubClient and Code Clean ups in AmqpEventHubClient

### DIFF
--- a/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
         AmqpServiceClient CreateAmpqServiceClient()
         {
             var client = new AmqpServiceClient(this, AmqpClientConstants.ManagementAddress);
-            Fx.Assert(string.Equals(this.managementServiceClient.Value.Address, AmqpClientConstants.ManagementAddress, StringComparison.OrdinalIgnoreCase),
+            Fx.Assert(string.Equals(client.Address, AmqpClientConstants.ManagementAddress, StringComparison.OrdinalIgnoreCase),
                 "The address should match the address of managementServiceClient");
             return client;
         }


### PR DESCRIPTION
## Description
- Acording to this is not really safe the double lock pattern w/o volatile at the bottom of the link is the official reference, here  is the change to replace specifically in `AmqpEventHubClient` for a Lazy instead.

Reference : https://help.semmle.com/wiki/display/CSHARP/Double-checked+lock+is+not+thread-safe

**AmqpEventHubClient Code CleanUps :** 
 - Remove internal to a few static methods that are only using privately  this will help if we can expose an interface for testing purpose

-  In OnGetPartitionRuntimeInformationAsync / OnGetRuntimeInformationAsync remove await and return task instead

- Create common Constructor to avoid repeated code in both ctors

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.