### PR TITLE
Fix Tests Moving Lazy initialization at the top of the ctor

### DIFF
--- a/src/Microsoft.Azure.EventHubs/EventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/EventHubClient.cs
@@ -23,10 +23,11 @@ namespace Microsoft.Azure.EventHubs
         internal EventHubClient(EventHubsConnectionStringBuilder csb)
             : base($"{nameof(EventHubClient)}{ClientEntity.GetNextId()}({csb.EntityPath})")
         {
+            this.innerSender = new Lazy<EventDataSender>(() => this.CreateEventSender());
+
             this.ConnectionStringBuilder = csb;
             this.EventHubName = csb.EntityPath;
             this.RetryPolicy = RetryPolicy.Default;
-            this.innerSender = new Lazy<EventDataSender>(() => this.CreateEventSender());
         }
 
         /// <summary>
@@ -527,24 +528,16 @@ namespace Microsoft.Azure.EventHubs
 
         /// <summary> Gets or sets a value indicating whether the runtime metric of a receiver is enabled. </summary>
         /// <value> true if a client wants to access <see cref="ReceiverRuntimeInformation"/> using <see cref="PartitionReceiver"/>. </value>
-        public bool EnableReceiverRuntimeMetric
-        {
-            get;
-            set;
-        }
+        public bool EnableReceiverRuntimeMetric { get; set; }
 
         /// <summary>
         /// Gets or sets the web proxy.
         /// A proxy is applicable only when transport type is set to AmqpWebSockets.
         /// If not set, systemwide proxy settings will be honored.
         /// </summary>
-        public IWebProxy WebProxy
-        {
-            get;
-            set;
-        }
+        public IWebProxy WebProxy { get; set; }
 
-        internal bool CloseCalled { get => this.closeCalled; }
+        internal bool CloseCalled => this.closeCalled;
 
         internal EventDataSender CreateEventSender(string partitionId = null)
         {

--- a/test/Microsoft.Azure.EventHubs.Tests/Amqp/AmqpMEssageCoverterTests.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Amqp/AmqpMEssageCoverterTests.cs
@@ -21,16 +21,14 @@ namespace Microsoft.Azure.EventHubs.Tests.Amqp
         void UpdateEventDataHeaderAndPropertiesReceiveCorrelationIdAndCopyItsValueToEventData()
         {
             // Arrange
-
             // the following simulates a message's round trip from client to broker to client
             var message = AmqpMessage.Create(new MemoryStream(new byte[12]), true);
             AddSection(message, SectionFlag.Properties);
             // serialize - send the message on client side
             ArraySegment<byte>[] buffers = ReadMessagePayLoad(message, 71);
-            EventData eventData;
-            
+
             // Act 
-            eventData = AmqpMessageConverter.AmqpMessageToEventData(message);
+            var eventData = AmqpMessageConverter.AmqpMessageToEventData(message);
 
             // Assert
             Assert.NotNull(eventData);


### PR DESCRIPTION
## Description
Null check is not neccesary the problem is that Policy is using the Retry before call the initialization so moving at the top of the ctor solve the problem

if the lazy inner is null at that moment there is other bug so I think null check will not make so much sense.

@serkantkaraca 

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.