### PR TITLE
Clean more results in sync context

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Azure.EventHubs.Primitives;
-
 namespace Microsoft.Azure.EventHubs.Processor
 {
     using System;
@@ -10,6 +8,7 @@ namespace Microsoft.Azure.EventHubs.Processor
     using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs.Primitives;
     using Newtonsoft.Json;
+    using Microsoft.Azure.EventHubs.Primitives;
     using WindowsAzure.Storage;
     using WindowsAzure.Storage.Blob;
 

--- a/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Azure.EventHubs.Primitives;
+
 namespace Microsoft.Azure.EventHubs.Processor
 {
     using System;
@@ -242,11 +244,7 @@ namespace Microsoft.Azure.EventHubs.Processor
 
         public IEnumerable<Task<Lease>> GetAllLeases()
         {
-            IEnumerable<string> partitionIds =
-                this.host.PartitionManager.GetPartitionIdsAsync()
-                    .ConfigureAwait(false)
-                    .GetAwaiter()
-                    .GetResult();
+            IEnumerable<string> partitionIds = this.host.PartitionManager.GetPartitionIdsAsync().WaitAndUnwrapException();
 
             foreach (string id in partitionIds)
             {

--- a/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.EventHubs.Processor
     using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs.Primitives;
     using Newtonsoft.Json;
-    using Microsoft.Azure.EventHubs.Primitives;
     using WindowsAzure.Storage;
     using WindowsAzure.Storage.Blob;
 

--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -222,9 +222,9 @@ namespace Microsoft.Azure.EventHubs.Processor
                         {
                             ourLeaseCount++;
                             ProcessorEventSource.Log.PartitionPumpInfo(this.host.HostName, lease.PartitionId, "Trying to renew lease.");
-                            renewLeaseTasks.Add(leaseManager.RenewLeaseAsync(lease).ContinueWith(async renewResult =>
+                            renewLeaseTasks.Add(leaseManager.RenewLeaseAsync(lease).ContinueWith(renewResult =>
                             {
-                                if (renewResult.IsFaulted || !await renewResult.ConfigureAwait(false))
+                                if (renewResult.IsFaulted || !renewResult.WaitAndUnwrapException())
                                 {
                                     // Might have failed due to intermittent error or lease-lost.
                                     // Just log here, expired leases will be picked by same or another host anyway.

--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.EventHubs.Processor
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.EventHubs.Primitives;
 
     class PartitionManager
     {
@@ -221,9 +222,9 @@ namespace Microsoft.Azure.EventHubs.Processor
                         {
                             ourLeaseCount++;
                             ProcessorEventSource.Log.PartitionPumpInfo(this.host.HostName, lease.PartitionId, "Trying to renew lease.");
-                            renewLeaseTasks.Add(leaseManager.RenewLeaseAsync(lease).ContinueWith(renewResult =>
+                            renewLeaseTasks.Add(leaseManager.RenewLeaseAsync(lease).ContinueWith(async renewResult =>
                             {
-                                if (renewResult.IsFaulted || !renewResult.Result)
+                                if (renewResult.IsFaulted || !await renewResult.ConfigureAwait(false))
                                 {
                                     // Might have failed due to intermittent error or lease-lost.
                                     // Just log here, expired leases will be picked by same or another host anyway.

--- a/src/Microsoft.Azure.EventHubs/Primitives/ExceptionUtility.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/ExceptionUtility.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.EventHubs
 {
     using System;
+    using System.Runtime.ExceptionServices;
 
     class ExceptionUtility
     {
@@ -35,6 +36,19 @@ namespace Microsoft.Azure.EventHubs
         public Exception AsError(Exception exception)
         {
             EventHubsEventSource.Log.ThrowingExceptionError(exception.ToString());
+            return exception;
+        }
+
+        /// <summary>
+        ///     Attempts to prepare the exception for re-throwing by preserving the stack trace. The returned exception should be immediately thrown.
+        /// </summary>
+        /// <param name="exception">The exception. May not be <c>null</c>.</param>
+        /// <returns>The <see cref="Exception"/> that was passed into this method.</returns>
+        public static Exception PrepareForRethrow(Exception exception)
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+            // The code cannot ever get here. We just return a value to work around a badly-designed API (ExceptionDispatchInfo.Throw):
+            //  https://connect.microsoft.com/VisualStudio/feedback/details/689516/exceptiondispatchinfo-api-modifications (http://www.webcitation.org/6XQ7RoJmO)
             return exception;
         }
     }

--- a/src/Microsoft.Azure.EventHubs/Primitives/TaskExtensions.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/TaskExtensions.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs.Primitives
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Provides synchronous extension methods for tasks.
+    /// </summary>
+    internal static class TaskExtensions
+    {
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        public static void WaitAndUnwrapException(this Task task)
+        {
+            // todo : use guard here
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            task.ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+        public static void WaitAndUnwrapException(this Task task, CancellationToken cancellationToken)
+        {
+            // todo : use guard here
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            try
+            {
+                task.Wait(cancellationToken);
+            }
+            catch (AggregateException ex)
+            {
+                throw ExceptionUtility.PrepareForRethrow(ex.InnerException);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the task.</typeparam>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <returns>The result of the task.</returns>
+        public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task)
+        {
+            // todo : use guard here
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            return task.ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the task.</typeparam>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>The result of the task.</returns>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+        public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task, CancellationToken cancellationToken)
+        {
+            // todo : use guard here
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            try
+            {
+                task.Wait(cancellationToken);
+                return task.Result;
+            }
+            catch (AggregateException ex)
+            {
+                throw ExceptionUtility.PrepareForRethrow(ex.InnerException);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, but does not raise task exceptions. The task exception (if any) is unobserved.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        public static void WaitWithoutException(this Task task)
+        {
+            // todo : use guard here
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, but does not raise task exceptions. The task exception (if any) is unobserved.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed.</exception>
+        public static void WaitWithoutException(this Task task, CancellationToken cancellationToken)
+        {
+            // todo : use guard here
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            try
+            {
+                task.Wait(cancellationToken);
+            }
+            catch (AggregateException)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.EventHubs/Primitives/TaskExtensions.cs
+++ b/src/Microsoft.Azure.EventHubs/Primitives/TaskExtensions.cs
@@ -18,12 +18,7 @@ namespace Microsoft.Azure.EventHubs.Primitives
         /// <param name="task">The task. May not be <c>null</c>.</param>
         public static void WaitAndUnwrapException(this Task task)
         {
-            // todo : use guard here
-            if (task == null)
-            {
-                throw new ArgumentNullException(nameof(task));
-            }
-
+            Guard.ArgumentNotNull(nameof(task), task);
             task.ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
@@ -35,11 +30,7 @@ namespace Microsoft.Azure.EventHubs.Primitives
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
         public static void WaitAndUnwrapException(this Task task, CancellationToken cancellationToken)
         {
-            // todo : use guard here
-            if (task == null)
-            {
-                throw new ArgumentNullException(nameof(task));
-            }
+            Guard.ArgumentNotNull(nameof(task), task);
 
             try
             {
@@ -59,12 +50,7 @@ namespace Microsoft.Azure.EventHubs.Primitives
         /// <returns>The result of the task.</returns>
         public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task)
         {
-            // todo : use guard here
-            if (task == null)
-            {
-                throw new ArgumentNullException(nameof(task));
-            }
-
+            Guard.ArgumentNotNull(nameof(task), task);
             return task.ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
@@ -78,11 +64,7 @@ namespace Microsoft.Azure.EventHubs.Primitives
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
         public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task, CancellationToken cancellationToken)
         {
-            // todo : use guard here
-            if (task == null)
-            {
-                throw new ArgumentNullException(nameof(task));
-            }
+            Guard.ArgumentNotNull(nameof(task), task);
 
             try
             {
@@ -101,11 +83,7 @@ namespace Microsoft.Azure.EventHubs.Primitives
         /// <param name="task">The task. May not be <c>null</c>.</param>
         public static void WaitWithoutException(this Task task)
         {
-            // todo : use guard here
-            if (task == null)
-            {
-                throw new ArgumentNullException(nameof(task));
-            }
+            Guard.ArgumentNotNull(nameof(task), task);
 
             try
             {
@@ -124,11 +102,7 @@ namespace Microsoft.Azure.EventHubs.Primitives
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed.</exception>
         public static void WaitWithoutException(this Task task, CancellationToken cancellationToken)
         {
-            // todo : use guard here
-            if (task == null)
-            {
-                throw new ArgumentNullException(nameof(task));
-            }
+            Guard.ArgumentNotNull(nameof(task), task);
 
             try
             {

--- a/test/Microsoft.Azure.EventHubs.Tests/Client/ClientTestBase.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Client/ClientTestBase.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+
 namespace Microsoft.Azure.EventHubs.Tests.Client
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.Azure.EventHubs.Primitives;
     using Xunit;
 
     public class ClientTestBase : IDisposable
@@ -20,7 +22,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             this.EventHubClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
             // Discover partition ids.
-            var eventHubInfo = this.EventHubClient.GetRuntimeInformationAsync().Result;
+            var eventHubInfo = this.EventHubClient.GetRuntimeInformationAsync().WaitAndUnwrapException();
             this.PartitionIds = eventHubInfo.PartitionIds;
             TestUtility.Log($"EventHub has {PartitionIds.Length} partitions");
         }

--- a/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.EventHubs.Primitives;
     using Microsoft.Azure.EventHubs.Processor;
     using Microsoft.IdentityModel.Clients.ActiveDirectory;
     using Microsoft.WindowsAzure.Storage;
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             // Discover partition ids.
             TestUtility.Log("Discovering partitions on eventhub");
             var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var eventHubInfo = ehClient.GetRuntimeInformationAsync().Result;
+            var eventHubInfo = ehClient.GetRuntimeInformationAsync().WaitAndUnwrapException();
             this.PartitionIds = eventHubInfo.PartitionIds;
             TestUtility.Log($"EventHub has {PartitionIds.Length} partitions");
         }


### PR DESCRIPTION
## Description
I've found 3 more Results in the code in a sync context.
so I propose 1 utility class to handle from now to the future w/o thinking in AggregateExceptions.

-2 of them are in the tests so it's not really a big problem
-1 was in a lambda so I just completed async there
- I've changed also the recent change in `AzureStorageCheckpointLeaseManager` to use this utility 

The idea if the change is accepted is using always this instead of `Result` or manual `GetAwaiter().GetResult()`

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.