### PR TITLE
Fix EPH flaky test

### DIFF
--- a/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
@@ -672,7 +672,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                         };
                 };
 
-                await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory);
+                var epo = EventProcessorOptions.DefaultOptions;
+                epo.ReceiveTimeout = TimeSpan.FromSeconds(15);
+                await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, epo);
 
                 // Wait 15 seconds then create a new epoch receiver.
                 // This will trigger ReceiverDisconnectedExcetion in the host.


### PR DESCRIPTION
Reducing receive timeout in EPH test to detect ReceiverDisconnectionException before sleep time is over.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.