### PR TITLE
Client changes to support SFP

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionPump.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionPump.cs
@@ -168,10 +168,7 @@ namespace Microsoft.Azure.EventHubs.Processor
                         this.PartitionContext.SetOffsetAndSequenceNumber(last);
                         if (this.Host.EventProcessorOptions.EnableReceiverRuntimeMetric)
                         {
-                            this.PartitionContext.RuntimeInformation.LastSequenceNumber = last.LastSequenceNumber;
-                            this.PartitionContext.RuntimeInformation.LastEnqueuedOffset = last.LastEnqueuedOffset;
-                            this.PartitionContext.RuntimeInformation.LastEnqueuedTimeUtc = last.LastEnqueuedTime;
-                            this.PartitionContext.RuntimeInformation.RetrievalTime = last.RetrievalTime;
+                            this.PartitionContext.RuntimeInformation.Update(last);
                         }
                     }
 

--- a/src/Microsoft.Azure.EventHubs/EventData.cs
+++ b/src/Microsoft.Azure.EventHubs/EventData.cs
@@ -114,6 +114,21 @@ namespace Microsoft.Azure.EventHubs
             {
             }
 
+            /// <summary>
+            /// Construct and initialize a new instance.
+            /// </summary>
+            /// <param name="sequenceNumber"></param>
+            /// <param name="enqueuedTimeUtc"></param>
+            /// <param name="offset"></param>
+            /// <param name="partitionKey"></param>
+            public SystemPropertiesCollection(long sequenceNumber, DateTime enqueuedTimeUtc, string offset, string partitionKey)
+            {
+                this[ClientConstants.SequenceNumberName] = sequenceNumber;
+                this[ClientConstants.EnqueuedTimeUtcName] = enqueuedTimeUtc;
+                this[ClientConstants.OffsetName] = offset;
+                this[ClientConstants.PartitionKeyName] = partitionKey;
+            }
+
             /// <summary>Gets the logical sequence number of the event within the partition stream of the Event Hub.</summary>
             public long SequenceNumber
             {

--- a/src/Microsoft.Azure.EventHubs/EventHubClient.cs
+++ b/src/Microsoft.Azure.EventHubs/EventHubClient.cs
@@ -194,7 +194,12 @@ namespace Microsoft.Azure.EventHubs
                 transportType);
         }
 
-        static EventHubClient Create(EventHubsConnectionStringBuilder csb)
+        /// <summary>
+        /// Creates a new instance of the Event Hubs client using the specified connection string builder.
+        /// </summary>
+        /// <param name="csb"></param>
+        /// <returns></returns>
+        public static EventHubClient Create(EventHubsConnectionStringBuilder csb)
         {
             Guard.ArgumentNotNull(nameof(csb), csb);
             Guard.ArgumentNotNullOrWhiteSpace(nameof(csb.EntityPath), csb.EntityPath);

--- a/src/Microsoft.Azure.EventHubs/PartitionReceiver.cs
+++ b/src/Microsoft.Azure.EventHubs/PartitionReceiver.cs
@@ -187,10 +187,7 @@ namespace Microsoft.Azure.EventHubs
                     // Update receiver runtime metrics?
                     if (this.ReceiverRuntimeMetricEnabled)
                     {
-                        this.RuntimeInfo.LastSequenceNumber = lastEvent.LastSequenceNumber;
-                        this.RuntimeInfo.LastEnqueuedOffset = lastEvent.LastEnqueuedOffset;
-                        this.RuntimeInfo.LastEnqueuedTimeUtc = lastEvent.LastEnqueuedTime;
-                        this.RuntimeInfo.RetrievalTime = lastEvent.RetrievalTime;
+                        this.RuntimeInfo.Update(lastEvent);
                     }
                 }
 

--- a/src/Microsoft.Azure.EventHubs/ReceiverRuntimeInfo.cs
+++ b/src/Microsoft.Azure.EventHubs/ReceiverRuntimeInfo.cs
@@ -8,7 +8,11 @@ namespace Microsoft.Azure.EventHubs
     /// <summary>Represents the approximate receiver runtime information for a logical partition of an Event Hub.</summary>
     public class ReceiverRuntimeInformation
     {
-        internal ReceiverRuntimeInformation(string partitionId)
+        /// <summary>
+        /// Construct a new instance for the given partition.
+        /// </summary>
+        /// <param name="partitionId"></param>
+        public ReceiverRuntimeInformation(string partitionId)
         {
             this.PartitionId = partitionId;
         }
@@ -32,5 +36,17 @@ namespace Microsoft.Azure.EventHubs
         /// <summary>Gets the time of when the runtime info was retrieved.</summary>
         /// <value>The enqueued time of the last event.</value>
         public DateTime RetrievalTime { get; internal set; }
+
+        /// <summary>
+        /// Update the properties of this instance with the values from the given event.
+        /// </summary>
+        /// <param name="updateFrom"></param>
+        public void Update(EventData updateFrom)
+        {
+            this.LastSequenceNumber = updateFrom.LastSequenceNumber;
+            this.LastEnqueuedOffset = updateFrom.LastEnqueuedOffset;
+            this.LastEnqueuedTimeUtc = updateFrom.LastEnqueuedTime;
+            this.RetrievalTime = updateFrom.RetrievalTime;
+        }
     }
 }


### PR DESCRIPTION
## Description

Three changes in the client needed to support SFP or SFP testing:

1) A previous PR added the ability to set EventData.SystemProperties, but it is not much use without the ability to create a new SystemPropertiesCollection instance. SFP testing does not need to set individual values on a SystemPropertiesCollection, just create new instances with values that do not change after creation time, so I added a public constructor which sets all the values.

2) SFP was previously creating EventHubClients with connection strings, but there is no string syntax for setting the operation timeout, and the message pump feature on PartitionReceiver uses the operation timeout. The easiest way to let SFP set the operation timeout is to make public the existing EventHubClient.Create call which takes a ConnectionStringBuilder.

3) Originally, SFP was a friend assembly of the client, the same as EPH, but it was decided that that was not the best design. Supporting the EnableReceiverRuntimeMetric option requires the ability to create new ReceiverRuntimeInformation instances (made constructor public) and update the values from a received EventData. Copying the values in SFP code would require making a bunch of properties on EventData public get, and the corresponding properties on ReceiverRuntimeInformation public set. Instead, I added an Update method which takes an EventData and performs the copy within the client assembly so no visibility change is required.