### PR TITLE
Set storage wait time for blob requests

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Azure.EventHubs.Processor
         TimeSpan leaseDuration;
         TimeSpan leaseRenewInterval;
 
-        static readonly TimeSpan storageMaximumExecutionTime = TimeSpan.FromMinutes(2);
+        static readonly TimeSpan storageMaximumExecutionTime = TimeSpan.FromMinutes(1);
+        static readonly TimeSpan storageServerWaitTime = TimeSpan.FromSeconds(30);
         readonly CloudStorageAccount cloudStorageAccount;
         readonly string leaseContainerName;
         readonly string storageBlobPrefix;
@@ -92,7 +93,8 @@ namespace Microsoft.Azure.EventHubs.Processor
             var storageClient = this.cloudStorageAccount.CreateCloudBlobClient();
             storageClient.DefaultRequestOptions = new BlobRequestOptions
             {
-                MaximumExecutionTime = AzureStorageCheckpointLeaseManager.storageMaximumExecutionTime
+                MaximumExecutionTime = AzureStorageCheckpointLeaseManager.storageMaximumExecutionTime,
+                ServerTimeout = AzureStorageCheckpointLeaseManager.storageServerWaitTime
             };
 
             this.eventHubContainer = storageClient.GetContainerReference(this.leaseContainerName);

--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.EventHubs.Processor
                 }
                 catch (Exception e)
                 {
-                    // TaskCancelledException is expected furing host unregister.
+                    // TaskCancelledException is expected during host unregister.
                     if (e is TaskCanceledException)
                     {
                         continue;


### PR DESCRIPTION
Storage calls are hanging intermittently. Setting server wait time to see if helps.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.