### PR TITLE
Don't skip expired lease check when lease owned by current host.

### DIFF
--- a/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Azure.EventHubs.Processor
 
                     // Check any expired leases that we can grab here.
                     var checkLeaseTasks = new List<Task>();
-                    foreach (var possibleLease in allLeases.Values.Where(lease => lease.Owner != this.host.HostName))
+                    foreach (var possibleLease in allLeases.Values)
                     {
                         var subjectLease = possibleLease;
 

--- a/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
@@ -955,7 +955,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
 
         [Fact]
         [DisplayTestMethodName]
-        async Task ReRegisterEventProcessor()
+        async Task ReRegister()
         {
             var eventProcessorHost = new EventProcessorHost(
                 null, // Entity path will be picked from connection string.
@@ -980,9 +980,14 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
 
         [Fact]
         [DisplayTestMethodName]
-        async Task ReRegisterSameHostName()
+        async Task ReRegisterAfterLeaseExpiry()
         {
             var hostName = Guid.NewGuid().ToString();
+
+            var processorOptions = new EventProcessorOptions
+            {
+                InitialOffsetProvider = pId => EventPosition.FromEnd()
+            };
 
             var eventProcessorHost = new EventProcessorHost(
                 hostName,
@@ -992,7 +997,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                 TestUtility.StorageConnectionString,
                 Guid.NewGuid().ToString());
 
-            var runResult = await RunGenericScenario(eventProcessorHost);
+            var runResult = await RunGenericScenario(eventProcessorHost, processorOptions);
             Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "First host: One of the partitions didn't return exactly 1 event");
 
             // Allow sometime so that leases can expire.

--- a/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
+++ b/test/Microsoft.Azure.EventHubs.Tests/Processor/ProcessorTestBase.cs
@@ -964,6 +964,31 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                 TestUtility.StorageConnectionString,
                 Guid.NewGuid().ToString());
 
+            var runResult = await RunGenericScenario(eventProcessorHost);
+            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "First host: One of the partitions didn't return exactly 1 event");
+
+            // Allow sometime so that leases can expire.
+            await Task.Delay(60);
+
+            runResult = await RunGenericScenario(eventProcessorHost);
+            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "Second host: One of the partitions didn't return exactly 1 event");
+        }
+
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task ReRegisterSameHostName()
+        {
+            var hostName = Guid.NewGuid().ToString();
+
+            var eventProcessorHost = new EventProcessorHost(
+                hostName,
+                null, // Entity path will be picked from connection string.
+                PartitionReceiver.DefaultConsumerGroupName,
+                TestUtility.EventHubsConnectionString,
+                TestUtility.StorageConnectionString,
+                Guid.NewGuid().ToString());
+
             // Calling register for the first time should succeed.
             TestUtility.Log("Registering EventProcessorHost for the first time.");
             await eventProcessorHost.RegisterEventProcessorAsync<SecondTestEventProcessor>();


### PR DESCRIPTION
This is a bug which impacts at single host cases. After unregister/register on the same host, host cannot acquire expired leases since expired check skips those.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.