### PR TITLE
Fix EventDataBatch accepting unsendable EventData

### DIFF
--- a/src/Microsoft.Azure.EventHubs/EventDataBatch.cs
+++ b/src/Microsoft.Azure.EventHubs/EventDataBatch.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.EventHubs
 
             this.ThrowIfDisposed();
             long size = GetEventSizeForBatch(eventData);
-            if (this.currentSize ?? 0 + size > this.maxSize)
+            if (this.currentSize + size > this.maxSize)
             {
                 return false;
             }

--- a/src/Microsoft.Azure.EventHubs/EventDataBatch.cs
+++ b/src/Microsoft.Azure.EventHubs/EventDataBatch.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.EventHubs
 
             this.ThrowIfDisposed();
             long size = GetEventSizeForBatch(eventData);
-            if (this.eventDataList.Count > 0 && this.currentSize + size > this.maxSize)
+            if (this.currentSize ?? 0 + size > this.maxSize)
             {
                 return false;
             }


### PR DESCRIPTION
## Description
bool TryAdd(EventData eventData) will accept items if they are the first item but are in excess of the maximum batchsize, so you successfully add to the batch but can't send it to EventHub.

Logically conflicts with this:
https://github.com/Azure/azure-event-hubs-dotnet/commit/067e3a702e754fbe947d787de18dcb68023a7350

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.