### PR TITLE
Update readme to point to newer packages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 
 # Microsoft Azure Event Hubs Client for .NET
 
+> Please note, newer packages [Azure.Messaging.EventHubs](https://www.nuget.org/packages/Azure.Messaging.EventHubs) and [Azure.Messaging.EventHubs.Processor](https://www.nuget.org/packages/Azure.Messaging.EventHubs.Processor) for [Azure Event Hubs](https://azure.microsoft.com/services/event-hubs/) are available as of February 2020. While the packages `Microsoft.Azure.EventHubs` and `Microsoft.Azure.EventHubs.Processor` will continue to receive critical bug fixes, we strongly encourage you to upgrade. Read the [migration guide](https://aka.ms/azsdk/net/migrate/eh) for more details.
+
 Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them into multiple applications. This lets you process and analyze the massive amounts of data produced by your connected devices and applications. Once Event Hubs has collected the data, you can retrieve, transform and store it by using any real-time analytics provider or with batching/storage adapters. 
 
 The Azure Events Hubs client library for .NET allows for both sending and receiving of events.  Most common scenarios call for an application to act as either an event publisher or an event consumer, but rarely both. 


### PR DESCRIPTION
This PR updates the repo readme for the older Event Hubs packages to include pointer to the new packages and the migration guide

As discussed offline, this is in an attempt to guide users to the new package where there is active development while the above packages continue to get critical bug fixes
